### PR TITLE
Make GPU optional for workspace

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ sequencer_proof_client = { path = "../sequencer_proof_client" }
 
 zkos_wrapper = { package = "zkos-wrapper", git = "https://github.com/matter-labs/zkos-wrapper.git", revision = "01a64a174c9d1c42e3dd9cc1ffebfdb3ddd1e873" }
 zksync_airbender_execution_utils = { package = "execution_utils", git = "https://github.com/matter-labs/zksync-airbender.git", tag = "v0.3.3" }
-zksync_airbender_cli = { package = "cli", git = "https://github.com/matter-labs/zksync-airbender.git", tag = "v0.3.3", features = ["gpu"] }
+zksync_airbender_cli = { package = "cli", git = "https://github.com/matter-labs/zksync-airbender.git", tag = "v0.3.3" }
 bellman = { package = "zksync_bellman", version = "=0.32.1" }
 circuit_definitions = "=0.152.2"
 crypto_codegen = { package = "zksync_solidity_vk_codegen", version = "=0.32.1" }

--- a/crates/zksync_os_snark_prover/Cargo.toml
+++ b/crates/zksync_os_snark_prover/Cargo.toml
@@ -31,3 +31,6 @@ anyhow.workspace = true
 tracing.workspace = true
 tracing-subscriber.workspace = true
 clap.workspace = true
+
+[features]
+default = ["zksync_airbender_cli/gpu"]


### PR DESCRIPTION
Enables FRI prover to be compiled without GPU. In the future we'll add better seggregation for this workflow. (working with GPU, without, etc for the entire prover stack)