### PR TITLE
fix: Register metrics

### DIFF
--- a/crates/sequencer_proof_client/src/metrics.rs
+++ b/crates/sequencer_proof_client/src/metrics.rs
@@ -18,5 +18,6 @@ pub struct SequencerClientMetrics {
     pub time_taken: Family<Method, Histogram>,
 }
 
+#[vise::register]
 pub(crate) static SEQUENCER_CLIENT_METRICS: vise::Global<SequencerClientMetrics> =
     vise::Global::new();

--- a/crates/zksync_os_fri_prover/src/metrics.rs
+++ b/crates/zksync_os_fri_prover/src/metrics.rs
@@ -32,4 +32,5 @@ pub struct FriProverMetrics {
     pub latest_proven_block: Gauge,
 }
 
+#[vise::register]
 pub(crate) static FRI_PROVER_METRICS: vise::Global<FriProverMetrics> = vise::Global::new();

--- a/crates/zksync_os_snark_prover/src/metrics.rs
+++ b/crates/zksync_os_snark_prover/src/metrics.rs
@@ -41,4 +41,5 @@ pub struct SnarkProverMetrics {
     pub latest_proven_block: Gauge,
 }
 
+#[vise::register]
 pub(crate) static SNARK_PROVER_METRICS: vise::Global<SnarkProverMetrics> = vise::Global::new();


### PR DESCRIPTION
Metrics were not emitted because they were not registered. This PR fixes it