### PR TITLE
fix: Fix .dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -3,4 +3,5 @@
 !Cargo*
 !rust-toolchain.toml
 !multiblock_batch.bin
+!docker/zksync-airbender-prover/entrypoint.sh
 !docker/zksync-os-prover-snark/entrypoint.sh


### PR DESCRIPTION
entry scripts for airbender-prover was missing, which broke docker image builds.