### PR TITLE
feat: announce supported VK hashes on each pick request

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5173,6 +5173,7 @@ dependencies = [
  "circuit_definitions",
  "clap",
  "execution_utils",
+ "protocol_version",
  "reqwest",
  "secrecy",
  "serde",

--- a/crates/sequencer_proof_client/Cargo.toml
+++ b/crates/sequencer_proof_client/Cargo.toml
@@ -12,6 +12,9 @@ categories.workspace = true
 
 [dependencies]
 
+# internal dependencies
+protocol_version.workspace = true
+
 # zksync-airbender dependencies
 zksync_airbender_execution_utils.workspace = true
 

--- a/crates/sequencer_proof_client/src/lib.rs
+++ b/crates/sequencer_proof_client/src/lib.rs
@@ -34,6 +34,14 @@ struct NextFriProverJobPayload {
     prover_input: String, // base64-encoded
 }
 
+/// Body sent on `POST /FRI/pick` and `POST /SNARK/pick`. The sequencer uses it
+/// to track which VK hashes each live prover can handle, so it can refuse to
+/// activate a protocol upgrade whose VK hash no prover supports.
+#[derive(Debug, Serialize, Deserialize)]
+pub(crate) struct PickJobRequest {
+    pub supported_vk_hashes: Vec<String>,
+}
+
 #[derive(Debug, Serialize, Deserialize)]
 struct SubmitFriProofPayload {
     batch_number: u64,

--- a/crates/sequencer_proof_client/src/main.rs
+++ b/crates/sequencer_proof_client/src/main.rs
@@ -1,5 +1,6 @@
 use anyhow::{anyhow, Result};
 use clap::{Parser, Subcommand};
+use protocol_version::SupportedProtocolVersions;
 use tracing_subscriber::{fmt, EnvFilter};
 use zkos_wrapper::SnarkWrapperProof;
 use zksync_sequencer_proof_client::{
@@ -47,6 +48,7 @@ impl Cli {
                 .clone()
                 .expect("called sequencer_client() before init()"),
             "cli_client".to_string(),
+            SupportedProtocolVersions::default().vk_hashes(),
             None,
         )
     }

--- a/crates/sequencer_proof_client/src/sequencer_proof_client.rs
+++ b/crates/sequencer_proof_client/src/sequencer_proof_client.rs
@@ -4,7 +4,7 @@ use crate::metrics::Method;
 use crate::sequencer_endpoint::SequencerEndpoint;
 use crate::{
     FailedFriProofPayload, FriJobInputs, GetSnarkProofPayload, NextFriProverJobPayload,
-    PeekableProofClient, ProofClient, SnarkProofInputs, SubmitFriProofPayload,
+    PeekableProofClient, PickJobRequest, ProofClient, SnarkProofInputs, SubmitFriProofPayload,
     SubmitSnarkProofPayload,
 };
 use crate::{L2BatchNumber, SEQUENCER_CLIENT_METRICS};
@@ -24,6 +24,9 @@ pub struct SequencerProofClient {
     client: reqwest::Client,
     endpoint: Url,
     prover_name: String,
+    /// VK hashes this prover will accept jobs for; echoed to the sequencer on
+    /// every `pick_*_job` so it can keep a live view of VK hashes provers support.
+    supported_vk_hashes: Vec<String>,
 }
 
 impl SequencerProofClient {
@@ -32,6 +35,7 @@ impl SequencerProofClient {
     /// # Arguments
     /// * `endpoint` - The sequencer endpoint (URL + optional credentials)
     /// * `prover_name` - The name of the prover (used for identification in sequencer prover api)
+    /// * `supported_vk_hashes` - VK hashes this prover can prove against
     /// * `timeout` - Optional timeout for requests (None defaults to 2 seconds)
     ///
     /// # Errors
@@ -39,6 +43,7 @@ impl SequencerProofClient {
     pub fn new(
         endpoint: SequencerEndpoint,
         prover_name: String,
+        supported_vk_hashes: Vec<String>,
         timeout: Option<Duration>,
     ) -> anyhow::Result<Self> {
         let mut headers = HeaderMap::new();
@@ -70,6 +75,7 @@ impl SequencerProofClient {
             client,
             endpoint: endpoint.url,
             prover_name,
+            supported_vk_hashes,
         })
     }
 
@@ -78,6 +84,7 @@ impl SequencerProofClient {
     /// # Arguments
     /// * `endpoints` - A vector of sequencer endpoints
     /// * `prover_name` - The name of the prover (used for identification in sequencer prover api)
+    /// * `supported_vk_hashes` - VK hashes this prover can prove against
     /// * `timeout` - Optional timeout for requests (None defaults to 2 seconds)
     ///
     /// # Errors
@@ -86,6 +93,7 @@ impl SequencerProofClient {
     pub fn new_clients(
         endpoints: Vec<SequencerEndpoint>,
         prover_name: String,
+        supported_vk_hashes: Vec<String>,
         timeout: Option<Duration>,
     ) -> anyhow::Result<Vec<Box<dyn ProofClient + Send + Sync>>> {
         if endpoints.is_empty() {
@@ -97,10 +105,13 @@ impl SequencerProofClient {
             .enumerate()
             .map(|(i, endpoint)| {
                 let url = endpoint.url.clone();
-                let client = SequencerProofClient::new(endpoint, prover_name.clone(), timeout)
-                    .with_context(|| {
-                        format!("Failed to create sequencer client #{i} at url {url:?}")
-                    })?;
+                let client = SequencerProofClient::new(
+                    endpoint,
+                    prover_name.clone(),
+                    supported_vk_hashes.clone(),
+                    timeout,
+                )
+                .with_context(|| format!("Failed to create sequencer client #{i} at url {url:?}"))?;
 
                 Ok(Box::new(client) as Box<dyn ProofClient + Send + Sync>)
             })
@@ -158,6 +169,9 @@ impl ProofClient for SequencerProofClient {
         let resp = self
             .client
             .post(url.clone())
+            .json(&PickJobRequest {
+                supported_vk_hashes: self.supported_vk_hashes.clone(),
+            })
             .send()
             .await
             .context("Pick Fri Job request failed")?;
@@ -230,6 +244,9 @@ impl ProofClient for SequencerProofClient {
         let resp = self
             .client
             .post(url.clone())
+            .json(&PickJobRequest {
+                supported_vk_hashes: self.supported_vk_hashes.clone(),
+            })
             .send()
             .await
             .context("Pick Snark Job request failed")?;
@@ -375,7 +392,7 @@ mod tests {
     fn test_client_strips_credentials() {
         let endpoint = SequencerEndpoint::parse("http://user:password123@localhost:3124").unwrap();
 
-        let client = SequencerProofClient::new(endpoint, "test_prover".to_string(), None)
+        let client = SequencerProofClient::new(endpoint, "test_prover".to_string(), vec![], None)
             .expect("failed to create client");
 
         // URL should be clean (no credentials)
@@ -389,7 +406,7 @@ mod tests {
     fn test_client_without_credentials() {
         let endpoint = SequencerEndpoint::parse("http://localhost:3124").unwrap();
 
-        let client = SequencerProofClient::new(endpoint, "test_prover".to_string(), None)
+        let client = SequencerProofClient::new(endpoint, "test_prover".to_string(), vec![], None)
             .expect("failed to create client");
 
         let url = client.sequencer_url();

--- a/crates/sequencer_proof_client/src/sequencer_proof_client.rs
+++ b/crates/sequencer_proof_client/src/sequencer_proof_client.rs
@@ -111,7 +111,9 @@ impl SequencerProofClient {
                     supported_vk_hashes.clone(),
                     timeout,
                 )
-                .with_context(|| format!("Failed to create sequencer client #{i} at url {url:?}"))?;
+                .with_context(|| {
+                    format!("Failed to create sequencer client #{i} at url {url:?}")
+                })?;
 
                 Ok(Box::new(client) as Box<dyn ProofClient + Send + Sync>)
             })

--- a/crates/zksync_os_fri_prover/src/lib.rs
+++ b/crates/zksync_os_fri_prover/src/lib.rs
@@ -124,18 +124,22 @@ pub async fn run(args: Args) -> anyhow::Result<()> {
         args.sequencer_urls
     );
 
-    let clients =
-        SequencerProofClient::new_clients(args.sequencer_urls, args.prover_name, Some(timeout))
-            .context("failed to create sequencer proof clients")?;
+    let supported_versions = SupportedProtocolVersions::default();
+    tracing::info!("{:#?}", supported_versions);
+
+    let clients = SequencerProofClient::new_clients(
+        args.sequencer_urls,
+        args.prover_name,
+        supported_versions.vk_hashes(),
+        Some(timeout),
+    )
+    .context("failed to create sequencer proof clients")?;
 
     let manifest_path = if let Ok(manifest_path) = std::env::var("CARGO_MANIFEST_DIR") {
         manifest_path
     } else {
         ".".to_string()
     };
-
-    let supported_versions = SupportedProtocolVersions::default();
-    tracing::info!("{:#?}", supported_versions);
 
     let binary_path = args
         .app_bin_path

--- a/crates/zksync_os_prover_service/src/lib.rs
+++ b/crates/zksync_os_prover_service/src/lib.rs
@@ -114,9 +114,16 @@ pub async fn run(args: Args) -> anyhow::Result<()> {
         args.sequencer_urls.len(),
         args.sequencer_urls
     );
-    let clients =
-        SequencerProofClient::new_clients(args.sequencer_urls, "prover_service".to_string(), None)
-            .context("failed to create sequencer proof clients")?;
+    let supported_versions = SupportedProtocolVersions::default();
+    tracing::info!("{:#?}", supported_versions);
+
+    let clients = SequencerProofClient::new_clients(
+        args.sequencer_urls,
+        "prover_service".to_string(),
+        supported_versions.vk_hashes(),
+        None,
+    )
+    .context("failed to create sequencer proof clients")?;
 
     let manifest_path = if let Ok(manifest_path) = std::env::var("CARGO_MANIFEST_DIR") {
         manifest_path
@@ -128,9 +135,6 @@ pub async fn run(args: Args) -> anyhow::Result<()> {
         .unwrap_or_else(|| Path::new(&manifest_path).join("../../multiblock_batch.bin"));
     let binary = load_binary_from_path(&binary_path.to_str().unwrap().to_string());
     let verifier_binary = get_padded_binary(UNIVERSAL_CIRCUIT_VERIFIER);
-
-    let supported_versions = SupportedProtocolVersions::default();
-    tracing::info!("{:#?}", supported_versions);
 
     #[cfg(feature = "gpu")]
     let precomputations = {

--- a/crates/zksync_os_snark_prover/src/main.rs
+++ b/crates/zksync_os_snark_prover/src/main.rs
@@ -1,6 +1,7 @@
 use std::time::Duration;
 
 use clap::{Parser, Subcommand};
+use protocol_version::SupportedProtocolVersions;
 use serde::{Deserialize, Serialize};
 use tokio::sync::watch;
 use zksync_os_snark_prover::{
@@ -134,9 +135,14 @@ fn main() {
                     sequencer_urls.len(),
                     sequencer_urls
                 );
-                let clients =
-                    SequencerProofClient::new_clients(sequencer_urls, prover_name, Some(timeout))
-                        .expect("failed to create sequencer proof clients");
+                let supported_versions = SupportedProtocolVersions::default();
+                let clients = SequencerProofClient::new_clients(
+                    sequencer_urls,
+                    prover_name,
+                    supported_versions.vk_hashes(),
+                    Some(timeout),
+                )
+                .expect("failed to create sequencer proof clients");
 
                 tracing::info!(
                     "Starting zksync_os_snark_prover with request timeout of {}s",


### PR DESCRIPTION
## Summary

Prover now advertises its supported VK hashes to the sequencer as the JSON body of every `pick_fri_job` / `pick_snark_job` POST.

The motivating use case is **protocol upgrade safety**: the sequencer should be able to refuse activating an upgrade whose target VK hash nobody in the live prover fleet actually supports, rather than silently stalling once the upgrade lands. This PR is the prover-side half — it makes the information available. The sequencer-side use (registry + upgrade gate in `zksync-os-server`) is a separate change.

Piggybacks on existing polling — no new port, no new endpoint, no separate registration lifecycle. Natural liveness: when a prover stops polling, the sequencer forgets it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)