### PR TITLE
ci(ZKD-3716): SBOM workflows

### DIFF
--- a/.github/scripts/create-dtrack-collection-project.sh
+++ b/.github/scripts/create-dtrack-collection-project.sh
@@ -1,4 +1,8 @@
 #!/usr/bin/env bash
+# Creates (or locates if already existing) a "collection" project in Dependency-Track.
+# A collection project aggregates the SBOMs of its children using AGGREGATE_LATEST_VERSION_CHILDREN,
+# so the parent project always reflects the combined vulnerability posture of the latest child versions.
+# On success the project UUID is printed to the log; downstream steps can scrape it from there.
 set -Eeuo pipefail
 IFS=$'\n\t'
 
@@ -30,6 +34,8 @@ main() {
 
   local http_response http_status response_body uuid
 
+  # PUT is idempotent in DT's API: 201 = created, 409 = already exists.
+  # The status code is appended after a newline so it can be split off from the body.
   http_response=$(curl -s -w "\n%{http_code}" \
     -X PUT "${DT_BASE_URL}/api/v1/project" \
     -H "X-Api-Key: ${DT_API_KEY}" \
@@ -51,6 +57,7 @@ main() {
     log "Project created."
     uuid=$(printf '%s' "${response_body}" | jq -r '.uuid')
   elif [[ "${http_status}" == "409" ]]; then
+    # Project already exists (e.g. re-running CI on the same version). Look it up by name+version.
     log "Project already exists, fetching existing project..."
     local existing
     existing=$(curl -sf --get \

--- a/.github/scripts/create-dtrack-collection-project.sh
+++ b/.github/scripts/create-dtrack-collection-project.sh
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+IFS=$'\n\t'
+
+usage() {
+  cat <<'EOF'
+Usage:
+  create-dtrack-collection-project.sh
+
+Required env:
+  DT_BASE_URL      Dependency Track base URL (e.g. https://dtrack.example.com)
+  DT_API_KEY       Dependency Track API key
+  PROJECT_NAME     Name for the collection project
+  PROJECT_VERSION  Version string (e.g. main, v1.0.0)
+  PARENT_UUID      UUID of the parent project
+EOF
+}
+
+log() { printf '[%s] %s\n' "$(date -u +'%Y-%m-%dT%H:%M:%SZ')" "$*"; }
+die() { printf 'ERROR: %s\n' "$*" >&2; exit 1; }
+
+main() {
+  : "${DT_BASE_URL:?Set DT_BASE_URL (e.g. https://dtrack.example.com)}"
+  : "${DT_API_KEY:?Set DT_API_KEY}"
+  : "${PROJECT_NAME:?Set PROJECT_NAME}"
+  : "${PROJECT_VERSION:?Set PROJECT_VERSION}"
+  : "${PARENT_UUID:?Set PARENT_UUID}"
+
+  log "Creating collection project '${PROJECT_NAME}' ${PROJECT_VERSION} under parent ${PARENT_UUID}..."
+
+  local http_response http_status response_body uuid
+
+  http_response=$(curl -s -w "\n%{http_code}" \
+    -X PUT "${DT_BASE_URL}/api/v1/project" \
+    -H "X-Api-Key: ${DT_API_KEY}" \
+    -H "Content-Type: application/json" \
+    -d '{
+      "name":            "'"${PROJECT_NAME}"'",
+      "version":         "'"${PROJECT_VERSION}"'",
+      "classifier":      "APPLICATION",
+      "active":          true,
+      "isLatest":        true,
+      "collectionLogic": "AGGREGATE_LATEST_VERSION_CHILDREN",
+      "parent":          {"uuid": "'"${PARENT_UUID}"'"}
+    }')
+
+  http_status=$(printf '%s' "${http_response}" | tail -n1)
+  response_body=$(printf '%s' "${http_response}" | head -n-1)
+
+  if [[ "${http_status}" == "201" ]]; then
+    log "Project created."
+    uuid=$(printf '%s' "${response_body}" | jq -r '.uuid')
+  elif [[ "${http_status}" == "409" ]]; then
+    log "Project already exists, fetching existing project..."
+    local existing
+    existing=$(curl -sf --get \
+      --data-urlencode "name=${PROJECT_NAME}" \
+      "${DT_BASE_URL}/api/v1/project" \
+      -H "X-Api-Key: ${DT_API_KEY}")
+    uuid=$(printf '%s' "${existing}" | jq -r --arg v "${PROJECT_VERSION}" '.[] | select(.version == $v) | .uuid')
+    [[ -z "${uuid}" ]] && die "Could not locate existing project '${PROJECT_NAME}' ${PROJECT_VERSION}"
+  else
+    log "Unexpected HTTP ${http_status}:"
+    printf '%s\n' "${response_body}" >&2
+    exit 1
+  fi
+
+  local project name version
+  project=$(curl -sf \
+    -X GET "${DT_BASE_URL}/api/v1/project/${uuid}" \
+    -H "X-Api-Key: ${DT_API_KEY}")
+
+  name=$(printf '%s' "${project}"    | jq -r '.name')
+  version=$(printf '%s' "${project}" | jq -r '.version // "n/a"')
+
+  log "Project UUID:    ${uuid}"
+  log "Project name:    ${name}"
+  log "Project version: ${version}"
+}
+
+main "$@"

--- a/.github/workflows/sbom-analysis-reusable.yaml
+++ b/.github/workflows/sbom-analysis-reusable.yaml
@@ -1,3 +1,17 @@
+# Reusable workflow: generates SBOMs for both source code and container images,
+# then uploads them to Dependency Track for vulnerability tracking.
+#
+# Structure:
+#   create-parent-project  — ensures a collection project exists in DT that will
+#                            aggregate vulnerabilities from all child projects below.
+#   sbom-code              — scans the source tree with Syft, produces a CycloneDX
+#                            SBOM, and uploads it as a child project "<repo>-code".
+#   sbom-image             — (matrix) pulls each container image from GHCR, scans it
+#                            with Syft, and uploads it as "<repo>-<app>-image".
+#
+# All three child projects are parented to the collection project so the DT dashboard
+# shows a single rolled-up view per version.
+
 name: SBOM generation and upload to Dependency Track
 
 on:
@@ -31,6 +45,7 @@ jobs:
 
   sbom-code:
     name: Generate and upload SBOM of the source code for analysis
+    # Must run after the parent collection project is guaranteed to exist.
     needs: create-parent-project
     runs-on: ubuntu-latest
     permissions:
@@ -63,11 +78,12 @@ jobs:
 
   sbom-image:
     name: Generate and upload SBOM of the container images for analysis
+    # Runs in parallel with sbom-code; one job per image in the matrix.
     needs: create-parent-project
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      packages: read
+      packages: read  # needed to pull images from GHCR
     strategy:
       matrix:
         app:

--- a/.github/workflows/sbom-analysis-reusable.yaml
+++ b/.github/workflows/sbom-analysis-reusable.yaml
@@ -8,9 +8,6 @@ on:
         required: true
         type: string
 
-env:
-  VERSION: "0.8.1"
-
 jobs:
   create-parent-project:
     name: Create or verify Dependency Track collection project

--- a/.github/workflows/sbom-analysis-reusable.yaml
+++ b/.github/workflows/sbom-analysis-reusable.yaml
@@ -1,12 +1,18 @@
 name: SBOM generation and upload to Dependency Track
 
 on:
-  workflow_call:
-    inputs:
-      version:
-        description: Version string to sync (e.g. 1.2.3)
-        required: true
-        type: string
+  push:
+    branches:
+      - ZKD-3716-sbom-workflows
+#  workflow_call:
+#    inputs:
+#      version:
+#        description: Version string to sync (e.g. 1.2.3)
+#        required: true
+#        type: string
+
+env:
+  VERSION: "0.8.1"
 
 jobs:
   create-parent-project:
@@ -24,7 +30,7 @@ jobs:
           DT_BASE_URL: https://${{ vars.DEPENDENCY_TRACK_SERVER_HOSTNAME }}
           DT_API_KEY: ${{ secrets.DEPENDENCY_TRACK_API_KEY }}
           PROJECT_NAME: ${{ github.event.repository.name }}
-          PROJECT_VERSION: ${{ inputs.version }}
+          PROJECT_VERSION: v${{ env.VERSION }}
           PARENT_UUID: ${{ vars.DEPENDENCY_TRACK_PARENT_PROJECT_UUID }}
 
   sbom-code:
@@ -50,12 +56,12 @@ jobs:
           serverhostname: ${{ vars.DEPENDENCY_TRACK_SERVER_HOSTNAME }}
           apikey: ${{ secrets.DEPENDENCY_TRACK_API_KEY }}
           projectname: "${{ github.event.repository.name }}-code"
-          projectversion: ${{ inputs.version }}
+          projectversion: v${{ env.VERSION }}
           isLatest: true
           bomfilename: "bom-code.cdx.json"
           autocreate: true
           parentname: ${{ github.event.repository.name }}
-          parentversion: ${{ inputs.version }}
+          parentversion: v${{ env.VERSION }}
 
   sbom-image:
     name: Generate and upload SBOM of the container images for analysis
@@ -66,7 +72,7 @@ jobs:
       packages: read
     strategy:
       matrix:
-        app: 
+        app:
           - zksync-airbender-prover
           - zksync-os-prover-fri
           - zksync-os-prover-snark
@@ -74,7 +80,7 @@ jobs:
       - name: Generate CycloneDX file on image analysis
         uses: anchore/sbom-action@e22c389904149dbc22b58101806040fa8d37a610 # v0.24.0
         with:
-          image: ghcr.io/${{ github.repository_owner }}/${{ matrix.app }}:${{ inputs.version }}
+          image: ghcr.io/${{ github.repository_owner }}/${{ matrix.app }}:v${{ env.VERSION }}
           registry-username: ${{ github.repository_owner }}
           registry-password: ${{ secrets.GITHUB_TOKEN }}
           output-file: "bom-${{ matrix.app }}-image.cdx.json"
@@ -88,9 +94,9 @@ jobs:
           serverhostname: ${{ vars.DEPENDENCY_TRACK_SERVER_HOSTNAME }}
           apikey: ${{ secrets.DEPENDENCY_TRACK_API_KEY }}
           projectname: "${{ github.event.repository.name }}-${{ matrix.app }}-image"
-          projectversion: ${{ inputs.version }}
+          projectversion: v${{ env.VERSION }}
           isLatest: true
           bomfilename: "bom-${{ matrix.app }}-image.cdx.json"
           autocreate: true
           parentname: ${{ github.event.repository.name }}
-          parentversion: ${{ inputs.version }}
+          parentversion: v${{ env.VERSION }}

--- a/.github/workflows/sbom-analysis-reusable.yaml
+++ b/.github/workflows/sbom-analysis-reusable.yaml
@@ -1,15 +1,12 @@
 name: SBOM generation and upload to Dependency Track
 
 on:
-  push:
-    branches:
-      - ZKD-3716-sbom-workflows
-#  workflow_call:
-#    inputs:
-#      version:
-#        description: Version string to sync (e.g. 1.2.3)
-#        required: true
-#        type: string
+  workflow_call:
+    inputs:
+      version:
+        description: Version string to sync (e.g. 1.2.3)
+        required: true
+        type: string
 
 env:
   VERSION: "0.8.1"
@@ -30,7 +27,7 @@ jobs:
           DT_BASE_URL: https://${{ vars.DEPENDENCY_TRACK_SERVER_HOSTNAME }}
           DT_API_KEY: ${{ secrets.DEPENDENCY_TRACK_API_KEY }}
           PROJECT_NAME: ${{ github.event.repository.name }}
-          PROJECT_VERSION: v${{ env.VERSION }}
+          PROJECT_VERSION: ${{ inputs.version }}
           PARENT_UUID: ${{ vars.DEPENDENCY_TRACK_PARENT_PROJECT_UUID }}
 
   sbom-code:
@@ -56,12 +53,12 @@ jobs:
           serverhostname: ${{ vars.DEPENDENCY_TRACK_SERVER_HOSTNAME }}
           apikey: ${{ secrets.DEPENDENCY_TRACK_API_KEY }}
           projectname: "${{ github.event.repository.name }}-code"
-          projectversion: v${{ env.VERSION }}
+          projectversion: ${{ inputs.version }}
           isLatest: true
           bomfilename: "bom-code.cdx.json"
           autocreate: true
           parentname: ${{ github.event.repository.name }}
-          parentversion: v${{ env.VERSION }}
+          parentversion: ${{ inputs.version }}
 
   sbom-image:
     name: Generate and upload SBOM of the container images for analysis
@@ -80,7 +77,7 @@ jobs:
       - name: Generate CycloneDX file on image analysis
         uses: anchore/sbom-action@e22c389904149dbc22b58101806040fa8d37a610 # v0.24.0
         with:
-          image: ghcr.io/${{ github.repository_owner }}/${{ matrix.app }}:v${{ env.VERSION }}
+          image: ghcr.io/${{ github.repository_owner }}/${{ matrix.app }}:${{ inputs.version }}
           registry-username: ${{ github.repository_owner }}
           registry-password: ${{ secrets.GITHUB_TOKEN }}
           output-file: "bom-${{ matrix.app }}-image.cdx.json"
@@ -94,9 +91,9 @@ jobs:
           serverhostname: ${{ vars.DEPENDENCY_TRACK_SERVER_HOSTNAME }}
           apikey: ${{ secrets.DEPENDENCY_TRACK_API_KEY }}
           projectname: "${{ github.event.repository.name }}-${{ matrix.app }}-image"
-          projectversion: v${{ env.VERSION }}
+          projectversion: ${{ inputs.version }}
           isLatest: true
           bomfilename: "bom-${{ matrix.app }}-image.cdx.json"
           autocreate: true
           parentname: ${{ github.event.repository.name }}
-          parentversion: v${{ env.VERSION }}
+          parentversion: ${{ inputs.version }}

--- a/.github/workflows/sbom-analysis-reusable.yaml
+++ b/.github/workflows/sbom-analysis-reusable.yaml
@@ -1,5 +1,17 @@
-# Reusable workflow: generates SBOMs for both source code and container images,
-# then uploads them to Dependency Track for vulnerability tracking.
+# Reusable workflow: generates SBOMs (Software Bill of Materials) for both source
+# code and container images, then uploads them to Dependency Track for vulnerability
+# tracking.
+#
+# An SBOM is a machine-readable inventory of every library and component that goes
+# into a software artifact.
+# It records each dependency's name, version, license, origin, and known
+# vulnerabilities at the time of the build, in a standardised format (CycloneDX
+# here). Having it continuously updated lets us:
+#   - detect newly disclosed CVEs in our dependencies without re-scanning manually;
+#   - satisfy security audits and compliance frameworks (SOC 2, ISO 27001, etc.)
+#     that require evidence of third-party component oversight;
+#   - respond quickly to supply-chain incidents (e.g. log4shell-style events) by
+#     knowing exactly which builds are affected.
 #
 # Structure:
 #   create-parent-project  — ensures a collection project exists in DT that will

--- a/.github/workflows/sbom-analysis-reusable.yaml
+++ b/.github/workflows/sbom-analysis-reusable.yaml
@@ -1,23 +1,19 @@
 name: SBOM generation and upload to Dependency Track
 
 on:
-  push:
-    branches:
-      - ZKD-3716-sbom-workflows
-#  workflow_call:
-#    inputs:
-#      version:
-#        description: Version string to sync (e.g. 1.2.3)
-#        required: true
-#        type: string
-
-env:
-  VERSION: "0.8.1"
+  workflow_call:
+    inputs:
+      version:
+        description: Version string to sync (e.g. 1.2.3)
+        required: true
+        type: string
 
 jobs:
   create-parent-project:
     name: Create or verify Dependency Track collection project
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Checkout code
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
@@ -30,13 +26,15 @@ jobs:
           DT_BASE_URL: https://${{ vars.DEPENDENCY_TRACK_SERVER_HOSTNAME }}
           DT_API_KEY: ${{ secrets.DEPENDENCY_TRACK_API_KEY }}
           PROJECT_NAME: ${{ github.event.repository.name }}
-          PROJECT_VERSION: v${{ env.VERSION }}
+          PROJECT_VERSION: ${{ inputs.version }}
           PARENT_UUID: ${{ vars.DEPENDENCY_TRACK_PARENT_PROJECT_UUID }}
 
   sbom-code:
     name: Generate and upload SBOM of the source code for analysis
     needs: create-parent-project
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Checkout code
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
@@ -56,12 +54,12 @@ jobs:
           serverhostname: ${{ vars.DEPENDENCY_TRACK_SERVER_HOSTNAME }}
           apikey: ${{ secrets.DEPENDENCY_TRACK_API_KEY }}
           projectname: "${{ github.event.repository.name }}-code"
-          projectversion: v${{ env.VERSION }}
+          projectversion: ${{ inputs.version }}
           isLatest: true
           bomfilename: "bom-code.cdx.json"
           autocreate: true
           parentname: ${{ github.event.repository.name }}
-          parentversion: v${{ env.VERSION }}
+          parentversion: ${{ inputs.version }}
 
   sbom-image:
     name: Generate and upload SBOM of the container images for analysis
@@ -80,7 +78,7 @@ jobs:
       - name: Generate CycloneDX file on image analysis
         uses: anchore/sbom-action@e22c389904149dbc22b58101806040fa8d37a610 # v0.24.0
         with:
-          image: ghcr.io/${{ github.repository_owner }}/${{ matrix.app }}:v${{ env.VERSION }}
+          image: ghcr.io/${{ github.repository_owner }}/${{ matrix.app }}:${{ inputs.version }}
           registry-username: ${{ github.repository_owner }}
           registry-password: ${{ secrets.GITHUB_TOKEN }}
           output-file: "bom-${{ matrix.app }}-image.cdx.json"
@@ -94,9 +92,9 @@ jobs:
           serverhostname: ${{ vars.DEPENDENCY_TRACK_SERVER_HOSTNAME }}
           apikey: ${{ secrets.DEPENDENCY_TRACK_API_KEY }}
           projectname: "${{ github.event.repository.name }}-${{ matrix.app }}-image"
-          projectversion: v${{ env.VERSION }}
+          projectversion: ${{ inputs.version }}
           isLatest: true
           bomfilename: "bom-${{ matrix.app }}-image.cdx.json"
           autocreate: true
           parentname: ${{ github.event.repository.name }}
-          parentversion: v${{ env.VERSION }}
+          parentversion: ${{ inputs.version }}

--- a/.github/workflows/sbom-analysis-reusable.yaml
+++ b/.github/workflows/sbom-analysis-reusable.yaml
@@ -1,0 +1,102 @@
+name: SBOM generation and upload to Dependency Track
+
+on:
+  push:
+    branches:
+      - ZKD-3716-sbom-workflows
+#  workflow_call:
+#    inputs:
+#      version:
+#        description: Version string to sync (e.g. 1.2.3)
+#        required: true
+#        type: string
+
+env:
+  VERSION: "0.8.1"
+
+jobs:
+  create-parent-project:
+    name: Create or verify Dependency Track collection project
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - name: Create or verify Dependency Track collection project
+        shell: bash
+        run: |
+          bash .github/scripts/create-dtrack-collection-project.sh
+        env:
+          DT_BASE_URL: https://${{ vars.DEPENDENCY_TRACK_SERVER_HOSTNAME }}
+          DT_API_KEY: ${{ secrets.DEPENDENCY_TRACK_API_KEY }}
+          PROJECT_NAME: ${{ github.event.repository.name }}
+          PROJECT_VERSION: v${{ env.VERSION }}
+          PARENT_UUID: ${{ vars.DEPENDENCY_TRACK_PARENT_PROJECT_UUID }}
+
+  sbom-code:
+    name: Generate and upload SBOM of the source code for analysis
+    needs: create-parent-project
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - name: Generate CycloneDX file on code analysis
+        uses: anchore/sbom-action@e22c389904149dbc22b58101806040fa8d37a610 # v0.24.0
+        with:
+          path: .
+          output-file: "bom-code.cdx.json"
+          format: 'cyclonedx-json@1.6'
+          upload-artifact: 'false'
+          upload-release-assets: 'false'
+
+      - name: Upload CycloneDX file to Dependency Track
+        uses: DependencyTrack/gh-upload-sbom@b717d6595efa77a7ff1b18b57ac28597afc75d77 # v4.0.0
+        with:
+          serverhostname: ${{ vars.DEPENDENCY_TRACK_SERVER_HOSTNAME }}
+          apikey: ${{ secrets.DEPENDENCY_TRACK_API_KEY }}
+          projectname: "${{ github.event.repository.name }}-code"
+          projectversion: v${{ env.VERSION }}
+          isLatest: true
+          bomfilename: "bom-code.cdx.json"
+          autocreate: true
+          parentname: ${{ github.event.repository.name }}
+          parentversion: v${{ env.VERSION }}
+
+  sbom-image:
+    name: Generate and upload SBOM of the container images for analysis
+    needs: create-parent-project
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: read
+    strategy:
+      matrix:
+        app: 
+          - zksync-airbender-prover
+          - zksync-os-prover-fri
+          - zksync-os-prover-snark
+    steps:
+      - name: Generate CycloneDX file on image analysis
+        uses: anchore/sbom-action@e22c389904149dbc22b58101806040fa8d37a610 # v0.24.0
+        with:
+          image: ghcr.io/${{ github.repository_owner }}/${{ matrix.app }}:v${{ env.VERSION }}
+          registry-username: ${{ github.repository_owner }}
+          registry-password: ${{ secrets.GITHUB_TOKEN }}
+          output-file: "bom-${{ matrix.app }}-image.cdx.json"
+          format: 'cyclonedx-json@1.6'
+          upload-artifact: 'false'
+          upload-release-assets: 'false'
+
+      - name: Upload CycloneDX file to Dependency Track
+        uses: DependencyTrack/gh-upload-sbom@b717d6595efa77a7ff1b18b57ac28597afc75d77 # v4.0.0
+        with:
+          serverhostname: ${{ vars.DEPENDENCY_TRACK_SERVER_HOSTNAME }}
+          apikey: ${{ secrets.DEPENDENCY_TRACK_API_KEY }}
+          projectname: "${{ github.event.repository.name }}-${{ matrix.app }}-image"
+          projectversion: v${{ env.VERSION }}
+          isLatest: true
+          bomfilename: "bom-${{ matrix.app }}-image.cdx.json"
+          autocreate: true
+          parentname: ${{ github.event.repository.name }}
+          parentversion: v${{ env.VERSION }}

--- a/.github/workflows/stage-build.yaml
+++ b/.github/workflows/stage-build.yaml
@@ -41,6 +41,8 @@ jobs:
           - zksync-airbender-prover
           - zksync-os-prover-fri
           - zksync-os-prover-snark
+    outputs:
+      sha_tag: ${{ steps.sha-tag.outputs.tag }}
     steps:
       - name: Checkout
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
@@ -99,3 +101,21 @@ jobs:
           push: ${{ github.event_name != 'pull_request' }}
           cache-from: 'type=registry,ref=ghcr.io/${{ github.repository_owner }}/${{ matrix.component }}:buildcache'
           cache-to: ${{ steps.set-cache-to.outputs.cache-to }}
+
+      - name: Extract SHA tag
+        id: sha-tag
+        run: |
+          SHA_TAG=$(echo "${{ steps.meta.outputs.tags }}" | tr ',' '\n' | grep -E '[0-9a-f]{7}-[0-9]+' | head -1 | cut -d':' -f2)
+          echo "tag=${SHA_TAG}" >> "${GITHUB_OUTPUT}"
+
+  sbom-generation:
+    name: SBOM
+    needs: [ 'build-images' ]
+    if: github.event_name != 'pull_request'
+    permissions:
+      contents: read
+      packages: read
+    uses: ./.github/workflows/sbom-analysis-reusable.yaml
+    secrets: inherit
+    with:
+      version: ${{ inputs.tag_name || (github.ref_type == 'tag' && github.ref_name) || needs.build-images.outputs.sha_tag }}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -118,9 +118,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.100"
+version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a23eb6b1614318a8071c9b2521f36b424b2c83db5eb3a0fead4a6c0809af6e61"
+checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
 
 [[package]]
 name = "arr_macro"
@@ -2142,9 +2142,9 @@ checksum = "32a282da65faaf38286cf3be983213fcf1d2e2a58700e808f83f4ea9a4804bc0"
 
 [[package]]
 name = "memmap2"
-version = "0.9.8"
+version = "0.9.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "843a98750cd611cc2965a8213b53b43e715f13c37a9e096c6408e69990961db7"
+checksum = "d1219ed1b7f229ee7104d281dd01d6802fe28bb6e95d292942c4daacdeb798c0"
 dependencies = [
  "libc",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,7 +42,8 @@ bellman = { package = "zksync_bellman", version = "=0.32.5" }
 crypto_codegen = { package = "zksync_solidity_vk_codegen", version = "=0.32.5" }
 
 # external dependencies
-anyhow = "1.0"
+anyhow = "1.0.103"
+memmap2 = "0.9.11"
 async-trait = "0.1"
 base64 = "0.22.1"
 bincode = { version = "2", features = ["serde"] }

--- a/deny.toml
+++ b/deny.toml
@@ -13,8 +13,6 @@ ignore = [
     "RUSTSEC-2024-0388", # `derivative` is unmaintained, crypto dependenicies (boojum, circuit_encodings and others) rely on it
     "RUSTSEC-2024-0436", # `paste` is an unmaintained dependency of various crates (like alloy-primitives, sqlx-core)
     "RUSTSEC-2025-0137", # unsoundness in reciprocal_mg10 - not used by our code
-    "RUSTSEC-2026-0190", # unsoundness in anyhow::Error::downcast_mut - fix is to upgrade to >=1.0.103
-    "RUSTSEC-2026-0186", # unchecked pointer offset in memmap2 - fix is to upgrade to >=0.9.11
 ]
 
 [licenses]

--- a/deny.toml
+++ b/deny.toml
@@ -13,6 +13,8 @@ ignore = [
     "RUSTSEC-2024-0388", # `derivative` is unmaintained, crypto dependenicies (boojum, circuit_encodings and others) rely on it
     "RUSTSEC-2024-0436", # `paste` is an unmaintained dependency of various crates (like alloy-primitives, sqlx-core)
     "RUSTSEC-2025-0137", # unsoundness in reciprocal_mg10 - not used by our code
+    "RUSTSEC-2026-0190", # unsoundness in anyhow::Error::downcast_mut - fix is to upgrade to >=1.0.103
+    "RUSTSEC-2026-0186", # unchecked pointer offset in memmap2 - fix is to upgrade to >=0.9.11
 ]
 
 [licenses]


### PR DESCRIPTION
## What

- Added GitHub workflow for generation and upload of the SBOMs to Dependency Track. The pipeline is triggered on new image release, generates SBOMs for the source code and the freshly pushed image using Syft and stores it in our Dependency Track

## Why

- SBOM tracking is required for security compliance and audits like SOC2 or ISO27k1