### PR TITLE
ci(release-please): bump reusable CI version

### DIFF
--- a/.github/workflows/release-please.yaml
+++ b/.github/workflows/release-please.yaml
@@ -19,10 +19,9 @@ on:
 jobs:
   # Prepare the release PR with changelog updates and create github releases
   release-please:
-    uses: matter-labs/zksync-ci-common/.github/workflows/release-please.yaml@v1 # use v1 to get bugfixes here instead of SHA
+    uses: matter-labs/zksync-ci-common/.github/workflows/release-please.yaml@c3b31c6f11bada204069c8b4621044e4c1cbc1df
     secrets:
       slack_webhook: ${{ secrets.SLACK_WEBHOOK_RELEASES }}  # Slack webhook for release notifications
-      cargo_registry_token: ${{ secrets.CRATES_IO_TOKEN }}  # Token for publishing to crates.io
       gh_token: ${{ secrets.RELEASE_TOKEN }}                # GitHub token for creating PRs and releases
     with:
       config: '.github/release-please/config.json'          # Path to the configuration file


### PR DESCRIPTION
## What ❔

- update versions of reusable workflows used to publish crates to crates.io. New version of those workflows use trusted publishing instead of static API tokens
- due to the limitation of trusted publishing, new crates in crates.io will have to be initially created by DevOps:
> Your crate must already be published to crates.io (initial publish requires an API token)

## Why ❔

- trusted publishing replaces long-lived crates.io API tokens with short-lived, OIDC-issued credentials scoped to a specific repo and workflow. This removes a standing secret that could leak and would need manual rotation, and follows crates.io's recommended publishing setup.

---
reusable CI changes: https://github.com/matter-labs/zksync-ci-common/pull/51/changes