### PR TITLE
chore: Move ownership to platform

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,4 +1,4 @@
-* @matter-labs/prover-subsystem
+* @matter-labs/platform
 .github/release-please/** @matter-labs/core-release-managers
 **/CHANGELOG.md @matter-labs/core-release-managers
 CODEOWNERS @RomanBrodetski @EmilLuta @popzxc @mm-zk


### PR DESCRIPTION
Given we're disbanding prover-subsystem, this repo should be owned by platform going forward.