### PR TITLE
[DO NOT MERGE] feat: Send protocol version during pick job (#141)

### DIFF
--- a/crates/sequencer_proof_client/src/main.rs
+++ b/crates/sequencer_proof_client/src/main.rs
@@ -42,12 +42,14 @@ impl Cli {
 
     /// Return sequencer client from CLI params. To be called only after `Cli::init()`.
     fn sequencer_client(&self) -> anyhow::Result<SequencerProofClient> {
+        // The CLI client declares no supported versions - the sequencer offers it any job.
         SequencerProofClient::new(
             self.url
                 .clone()
                 .expect("called sequencer_client() before init()"),
             "cli_client".to_string(),
             None,
+            vec![],
         )
     }
 }

--- a/crates/sequencer_proof_client/src/sequencer_proof_client.rs
+++ b/crates/sequencer_proof_client/src/sequencer_proof_client.rs
@@ -24,6 +24,7 @@ pub struct SequencerProofClient {
     client: reqwest::Client,
     endpoint: Url,
     prover_name: String,
+    supported_vk_hashes: Vec<String>,
 }
 
 impl SequencerProofClient {
@@ -33,6 +34,9 @@ impl SequencerProofClient {
     /// * `endpoint` - The sequencer endpoint (URL + optional credentials)
     /// * `prover_name` - The name of the prover (used for identification in sequencer prover api)
     /// * `timeout` - Optional timeout for requests (None defaults to 2 seconds)
+    /// * `supported_vk_hashes` - VK hashes this prover supports; sent on pick requests so the
+    ///   sequencer only assigns jobs of these versions. Empty means no declaration - the
+    ///   sequencer will offer jobs of any version.
     ///
     /// # Errors
     /// * if building the reqwest client fails
@@ -40,6 +44,7 @@ impl SequencerProofClient {
         endpoint: SequencerEndpoint,
         prover_name: String,
         timeout: Option<Duration>,
+        supported_vk_hashes: Vec<String>,
     ) -> anyhow::Result<Self> {
         let mut headers = HeaderMap::new();
 
@@ -70,6 +75,7 @@ impl SequencerProofClient {
             client,
             endpoint: endpoint.url,
             prover_name,
+            supported_vk_hashes,
         })
     }
 
@@ -79,6 +85,9 @@ impl SequencerProofClient {
     /// * `endpoints` - A vector of sequencer endpoints
     /// * `prover_name` - The name of the prover (used for identification in sequencer prover api)
     /// * `timeout` - Optional timeout for requests (None defaults to 2 seconds)
+    /// * `supported_vk_hashes` - VK hashes this prover supports; sent on pick requests so the
+    ///   sequencer only assigns jobs of these versions. Empty means no declaration - the
+    ///   sequencer will offer jobs of any version.
     ///
     /// # Errors
     /// * if there are no endpoints provided (empty vector)
@@ -87,6 +96,7 @@ impl SequencerProofClient {
         endpoints: Vec<SequencerEndpoint>,
         prover_name: String,
         timeout: Option<Duration>,
+        supported_vk_hashes: Vec<String>,
     ) -> anyhow::Result<Vec<Box<dyn ProofClient + Send + Sync>>> {
         if endpoints.is_empty() {
             return Err(anyhow!("No sequencer endpoints provided"));
@@ -97,10 +107,15 @@ impl SequencerProofClient {
             .enumerate()
             .map(|(i, endpoint)| {
                 let url = endpoint.url.clone();
-                let client = SequencerProofClient::new(endpoint, prover_name.clone(), timeout)
-                    .with_context(|| {
-                        format!("Failed to create sequencer client #{i} at url {url:?}")
-                    })?;
+                let client = SequencerProofClient::new(
+                    endpoint,
+                    prover_name.clone(),
+                    timeout,
+                    supported_vk_hashes.clone(),
+                )
+                .with_context(|| {
+                    format!("Failed to create sequencer client #{i} at url {url:?}")
+                })?;
 
                 Ok(Box::new(client) as Box<dyn ProofClient + Send + Sync>)
             })
@@ -142,6 +157,21 @@ impl SequencerProofClient {
             .with_context(|| format!("Failed to build URL for path: {path}"))?;
         Ok(url)
     }
+
+    /// Query string for pick requests: prover id plus, if declared, the supported VK hashes.
+    /// Sequencers aware of `supported_vk_hashes` only assign jobs of these versions;
+    /// older sequencers ignore the parameter.
+    fn pick_query(&self) -> String {
+        if self.supported_vk_hashes.is_empty() {
+            format!("id={}", self.prover_name)
+        } else {
+            format!(
+                "id={}&supported_vk_hashes={}",
+                self.prover_name,
+                self.supported_vk_hashes.join(",")
+            )
+        }
+    }
 }
 
 #[async_trait]
@@ -151,7 +181,7 @@ impl ProofClient for SequencerProofClient {
     }
 
     async fn pick_fri_job(&self) -> anyhow::Result<Option<FriJobInputs>> {
-        let url = self.build_url(&format!("FRI/pick?id={}", self.prover_name))?;
+        let url = self.build_url(&format!("FRI/pick?{}", self.pick_query()))?;
 
         let started_at = Instant::now();
 
@@ -223,7 +253,7 @@ impl ProofClient for SequencerProofClient {
     }
 
     async fn pick_snark_job(&self) -> anyhow::Result<Option<SnarkProofInputs>> {
-        let url = self.build_url(&format!("SNARK/pick?id={}", self.prover_name))?;
+        let url = self.build_url(&format!("SNARK/pick?{}", self.pick_query()))?;
 
         let started_at = Instant::now();
 
@@ -375,7 +405,7 @@ mod tests {
     fn test_client_strips_credentials() {
         let endpoint = SequencerEndpoint::parse("http://user:password123@localhost:3124").unwrap();
 
-        let client = SequencerProofClient::new(endpoint, "test_prover".to_string(), None)
+        let client = SequencerProofClient::new(endpoint, "test_prover".to_string(), None, vec![])
             .expect("failed to create client");
 
         // URL should be clean (no credentials)
@@ -386,10 +416,36 @@ mod tests {
     }
 
     #[test]
+    fn test_pick_query_without_supported_vk_hashes() {
+        let endpoint = SequencerEndpoint::parse("http://localhost:3124").unwrap();
+        let client = SequencerProofClient::new(endpoint, "test_prover".to_string(), None, vec![])
+            .expect("failed to create client");
+
+        assert_eq!(client.pick_query(), "id=test_prover");
+    }
+
+    #[test]
+    fn test_pick_query_with_supported_vk_hashes() {
+        let endpoint = SequencerEndpoint::parse("http://localhost:3124").unwrap();
+        let client = SequencerProofClient::new(
+            endpoint,
+            "test_prover".to_string(),
+            None,
+            vec!["0xaaaa".to_string(), "0xbbbb".to_string()],
+        )
+        .expect("failed to create client");
+
+        assert_eq!(
+            client.pick_query(),
+            "id=test_prover&supported_vk_hashes=0xaaaa,0xbbbb"
+        );
+    }
+
+    #[test]
     fn test_client_without_credentials() {
         let endpoint = SequencerEndpoint::parse("http://localhost:3124").unwrap();
 
-        let client = SequencerProofClient::new(endpoint, "test_prover".to_string(), None)
+        let client = SequencerProofClient::new(endpoint, "test_prover".to_string(), None, vec![])
             .expect("failed to create client");
 
         let url = client.sequencer_url();

--- a/crates/zksync_os_fri_prover/src/lib.rs
+++ b/crates/zksync_os_fri_prover/src/lib.rs
@@ -124,18 +124,22 @@ pub async fn run(args: Args) -> anyhow::Result<()> {
         args.sequencer_urls
     );
 
-    let clients =
-        SequencerProofClient::new_clients(args.sequencer_urls, args.prover_name, Some(timeout))
-            .context("failed to create sequencer proof clients")?;
+    let supported_versions = SupportedProtocolVersions::default();
+    tracing::info!("{:#?}", supported_versions);
+
+    let clients = SequencerProofClient::new_clients(
+        args.sequencer_urls,
+        args.prover_name,
+        Some(timeout),
+        supported_versions.vk_hashes(),
+    )
+    .context("failed to create sequencer proof clients")?;
 
     let manifest_path = if let Ok(manifest_path) = std::env::var("CARGO_MANIFEST_DIR") {
         manifest_path
     } else {
         ".".to_string()
     };
-
-    let supported_versions = SupportedProtocolVersions::default();
-    tracing::info!("{:#?}", supported_versions);
 
     let binary_path = args
         .app_bin_path

--- a/crates/zksync_os_prover_service/src/lib.rs
+++ b/crates/zksync_os_prover_service/src/lib.rs
@@ -114,9 +114,16 @@ pub async fn run(args: Args) -> anyhow::Result<()> {
         args.sequencer_urls.len(),
         args.sequencer_urls
     );
-    let clients =
-        SequencerProofClient::new_clients(args.sequencer_urls, "prover_service".to_string(), None)
-            .context("failed to create sequencer proof clients")?;
+    let supported_versions = SupportedProtocolVersions::default();
+    tracing::info!("{:#?}", supported_versions);
+
+    let clients = SequencerProofClient::new_clients(
+        args.sequencer_urls,
+        "prover_service".to_string(),
+        None,
+        supported_versions.vk_hashes(),
+    )
+    .context("failed to create sequencer proof clients")?;
 
     let manifest_path = if let Ok(manifest_path) = std::env::var("CARGO_MANIFEST_DIR") {
         manifest_path
@@ -128,9 +135,6 @@ pub async fn run(args: Args) -> anyhow::Result<()> {
         .unwrap_or_else(|| Path::new(&manifest_path).join("../../multiblock_batch.bin"));
     let binary = load_binary_from_path(&binary_path.to_str().unwrap().to_string());
     let verifier_binary = get_padded_binary(UNIVERSAL_CIRCUIT_VERIFIER);
-
-    let supported_versions = SupportedProtocolVersions::default();
-    tracing::info!("{:#?}", supported_versions);
 
     #[cfg(feature = "gpu")]
     let precomputations = {

--- a/crates/zksync_os_snark_prover/src/main.rs
+++ b/crates/zksync_os_snark_prover/src/main.rs
@@ -1,6 +1,7 @@
 use std::time::Duration;
 
 use clap::{Parser, Subcommand};
+use protocol_version::SupportedProtocolVersions;
 use serde::{Deserialize, Serialize};
 use tokio::sync::watch;
 use zksync_os_snark_prover::{
@@ -134,9 +135,14 @@ fn main() {
                     sequencer_urls.len(),
                     sequencer_urls
                 );
-                let clients =
-                    SequencerProofClient::new_clients(sequencer_urls, prover_name, Some(timeout))
-                        .expect("failed to create sequencer proof clients");
+                let supported_versions = SupportedProtocolVersions::default();
+                let clients = SequencerProofClient::new_clients(
+                    sequencer_urls,
+                    prover_name,
+                    Some(timeout),
+                    supported_versions.vk_hashes(),
+                )
+                .expect("failed to create sequencer proof clients");
 
                 tracing::info!(
                     "Starting zksync_os_snark_prover with request timeout of {}s",


### PR DESCRIPTION
v0.7.1 that is currently running in some envs (everything running on protocol version v0.30 requires it).

Hotfix applied from v0.8.2. (see commit [here](https://github.com/matter-labs/zksync-airbender-prover/pull/141))

This branch is used only to create a tag from (and image) to be deployed before v0.31 goes live. Will make deployments easier.