### PR TITLE
feat: bind protocol versions to their app program's chain commitment

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5634,6 +5634,7 @@ dependencies = [
  "url",
  "vise",
  "vise-exporter",
+ "zkos-wrapper",
  "zksync_sequencer_proof_client",
 ]
 

--- a/crates/protocol_version/src/lib.rs
+++ b/crates/protocol_version/src/lib.rs
@@ -21,19 +21,15 @@ struct ProtocolVersion {
     /// NOTE2: this can be inferred from zksync_os_version, but we keep it here for easier cross-checking
     bin_md5sum: BinMd5Sum,
     /// Chain commitment of the app program this version proves (see [`ProgramCommitment`]).
-    ///
-    /// Since V8 the SNARK VK is app-independent, so `vk_hash` alone no longer identifies
-    /// the app binary; the (vk_hash, program_commitment) pair does. `None` for pre-V8
-    /// versions, whose VK had the binary commitment baked into the circuit.
+    /// Since V8 the SNARK VK is app-independent, so the (vk_hash, program_commitment)
+    /// pair is what identifies a version. `None` pre-V8 (VK covered the binary).
     program_commitment: Option<ProgramCommitment>,
 }
 
-/// The blake2s recursion-chain commitment binding a protocol version to its app program
-/// (`multiblock_batch.bin`/`.text`): the base program's `end_params` folded with the
-/// unrolled recursion verifier's, exactly the value the unified recursion verifier
-/// exposes in its final registers 18..=25 and the settlement side checks the SNARK
-/// public input against. Computed with zkos-wrapper's `BinaryCommitment::from_base_binary`
-/// (`aux_params`); see `zksync_os_fri_prover::compute_program_commitment`.
+/// Blake2s recursion-chain commitment binding a protocol version to its app program:
+/// the base program's `end_params` folded with the unrolled recursion verifier's — the
+/// value proofs expose in final registers 18..=25 and the settlement side checks the
+/// SNARK public input against. See `zksync_os_fri_prover::compute_program_commitment`.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct ProgramCommitment(pub [u32; 8]);
 
@@ -168,9 +164,8 @@ impl SupportedProtocolVersions {
             .collect()
     }
 
-    /// Returns the app-program commitment recorded for the version with this VK hash.
-    ///
-    /// `None` if the version is not supported, or predates program commitments (pre-V8).
+    /// The app-program commitment recorded for the version with this VK hash;
+    /// `None` if the version is unsupported or pre-V8.
     pub fn program_commitment_for(&self, vk_hash: &str) -> Option<ProgramCommitment> {
         self.versions
             .iter()

--- a/crates/protocol_version/src/lib.rs
+++ b/crates/protocol_version/src/lib.rs
@@ -20,6 +20,31 @@ struct ProtocolVersion {
     /// NOTE: in the future we may want to support multiple binaries (such as debug mode)
     /// NOTE2: this can be inferred from zksync_os_version, but we keep it here for easier cross-checking
     bin_md5sum: BinMd5Sum,
+    /// Chain commitment of the app program this version proves (see [`ProgramCommitment`]).
+    ///
+    /// Since V8 the SNARK VK is app-independent, so `vk_hash` alone no longer identifies
+    /// the app binary; the (vk_hash, program_commitment) pair does. `None` for pre-V8
+    /// versions, whose VK had the binary commitment baked into the circuit.
+    program_commitment: Option<ProgramCommitment>,
+}
+
+/// The blake2s recursion-chain commitment binding a protocol version to its app program
+/// (`multiblock_batch.bin`/`.text`): the base program's `end_params` folded with the
+/// unrolled recursion verifier's, exactly the value the unified recursion verifier
+/// exposes in its final registers 18..=25 and the settlement side checks the SNARK
+/// public input against. Computed with zkos-wrapper's `BinaryCommitment::from_base_binary`
+/// (`aux_params`); see `zksync_os_fri_prover::compute_program_commitment`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ProgramCommitment(pub [u32; 8]);
+
+impl std::fmt::Display for ProgramCommitment {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "0x")?;
+        for word in self.0 {
+            write!(f, "{word:08x}")?;
+        }
+        Ok(())
+    }
 }
 
 #[derive(Debug)]
@@ -47,6 +72,7 @@ const V3: ProtocolVersion = ProtocolVersion {
     zksync_os_version: ZkSyncOSVersion("v0.0.26"),
     zkos_wrapper: ZkOsWrapperVersion("v0.5.0"),
     bin_md5sum: BinMd5Sum("fd9fd6ebfcfe7b3d1557e8a8b8563dd6"),
+    program_commitment: None,
 };
 
 /// Corresponds to server's execution_version 4 (or v1.2)
@@ -59,6 +85,7 @@ const V4: ProtocolVersion = ProtocolVersion {
     zksync_os_version: ZkSyncOSVersion("v0.1.0"),
     zkos_wrapper: ZkOsWrapperVersion("v0.5.3"),
     bin_md5sum: BinMd5Sum("a3fffd4f2e14e7171c2207e470316e5f"),
+    program_commitment: None,
 };
 
 /// Corresponds to server's execution_version 5 (or v1.3)
@@ -71,6 +98,7 @@ const V5: ProtocolVersion = ProtocolVersion {
     zksync_os_version: ZkSyncOSVersion("v0.2.4"),
     zkos_wrapper: ZkOsWrapperVersion("v0.5.3"),
     bin_md5sum: BinMd5Sum("a2421384eb817ba2649f1438dc321d54"),
+    program_commitment: None,
 };
 
 /// Corresponds to server's execution_version 6 (or v1.3.1)
@@ -83,6 +111,7 @@ const V6: ProtocolVersion = ProtocolVersion {
     zksync_os_version: ZkSyncOSVersion("v0.2.5"),
     zkos_wrapper: ZkOsWrapperVersion("v0.5.4"),
     bin_md5sum: BinMd5Sum("e77ced130723f3e52099658d589a8454"),
+    program_commitment: None,
 };
 
 /// Corresponds to server's execution_version 7
@@ -95,6 +124,7 @@ const V7: ProtocolVersion = ProtocolVersion {
     zksync_os_version: ZkSyncOSVersion("v0.3.0"),
     zkos_wrapper: ZkOsWrapperVersion("v0.5.5"),
     bin_md5sum: BinMd5Sum("99d1618fdf63d80c4a6ed41cf21ed4d6"),
+    program_commitment: None,
 };
 
 /// Corresponds to server's execution_version 8 (protocol v32.0, zksync-os 0.4.0 native batch prover)
@@ -106,6 +136,10 @@ const V8: ProtocolVersion = ProtocolVersion {
     zksync_os_version: ZkSyncOSVersion("v0.4.0"),
     zkos_wrapper: ZkOsWrapperVersion("v0.6.0-rc.1"),
     bin_md5sum: BinMd5Sum("3e19df8c36564939950e0a079061ad1b"),
+    program_commitment: Some(ProgramCommitment([
+        0x925e5e40, 0xf526b71c, 0x1ee4f8b1, 0xea01856f, 0xf2f836fb, 0x19b96ed6, 0xb36a9404,
+        0x248d5773,
+    ])),
 };
 
 /// Represents the set of supported protocol versions by this prover implementation.
@@ -132,5 +166,22 @@ impl SupportedProtocolVersions {
             .iter()
             .map(|version| version.vk_hash.0.to_string())
             .collect()
+    }
+
+    /// Returns the app-program commitment recorded for the version with this VK hash.
+    ///
+    /// `None` if the version is not supported, or predates program commitments (pre-V8).
+    pub fn program_commitment_for(&self, vk_hash: &str) -> Option<ProgramCommitment> {
+        self.versions
+            .iter()
+            .find(|v| v.vk_hash.0 == vk_hash)
+            .and_then(|v| v.program_commitment)
+    }
+
+    /// Checks whether some supported version proves the app program with this commitment.
+    pub fn supports_program(&self, commitment: &ProgramCommitment) -> bool {
+        self.versions
+            .iter()
+            .any(|v| v.program_commitment.as_ref() == Some(commitment))
     }
 }

--- a/crates/zksync_os_fri_prover/Cargo.toml
+++ b/crates/zksync_os_fri_prover/Cargo.toml
@@ -19,6 +19,12 @@ zksync_sequencer_proof_client.workspace = true
 zksync_airbender_cli.workspace = true
 zksync_airbender_execution_utils.workspace = true
 
+# zkos-wrapper dependencies
+# Used only to derive the app program's chain commitment with the exact same code the
+# SNARK wrapper chain uses (`BinaryCommitment::from_base_binary`), so the value can't
+# drift from what the settlement side enforces.
+zkos_wrapper.workspace = true
+
 # external dependencies
 anyhow.workspace = true
 base64.workspace = true

--- a/crates/zksync_os_fri_prover/src/lib.rs
+++ b/crates/zksync_os_fri_prover/src/lib.rs
@@ -97,31 +97,18 @@ pub fn create_prover(binary_path: &Path) -> anyhow::Result<ProgramProver> {
     ProgramProver::new(source, config).map_err(|e| anyhow::anyhow!("failed to create prover: {e}"))
 }
 
-/// Compute the chain commitment of the app program at `binary_path` (`.text` sibling
-/// derived like [`create_prover`] does).
+/// Compute the [`ProgramCommitment`] of the app program at `binary_path` (`.text`
+/// sibling derived like [`create_prover`] does).
 ///
-/// This is the blake2s recursion-chain value — the base program's `end_params` folded
-/// with the unrolled recursion verifier's — that proofs of this program expose in their
-/// final registers 18..=25 and that the settlement side checks the SNARK public input
-/// against. Since V8 the SNARK VK no longer covers the app binary, so the
-/// (vk_hash, program commitment) pair is what identifies a protocol version end to end;
-/// comparing this value against the [`SupportedProtocolVersions`] table catches a
-/// "right prover stack, wrong binary" deployment before any proving starts.
+/// Uses zkos-wrapper's own `BinaryCommitment`, so the value is byte-identical to what
+/// the wrapper chain enforces — but that recomputes the program's setup caps, which
+/// takes on the order of a minute. Call once at startup.
 ///
-/// Derived with zkos-wrapper's own `BinaryCommitment` so the value is byte-identical to
-/// what the wrapper chain enforces. Note this recomputes the program's setup caps
-/// (the prover's own copy in [`create_prover`] is not accessible), which takes on the
-/// order of a minute — call it once at startup.
-///
-/// TODO: the GPU prover already computes this exact value at construction —
-/// airbender's `UnrolledProver::level_data[RecursionUnrolled].hash_chain` is this chain
-/// (the unified level's is one fold too far); only `ProgramProver`'s private `inner`
-/// field keeps it out of reach. When cutting the next airbender + zkos-wrapper tag pair
-/// (non-rc), add an accessor upstream returning `Option<[u32; 8]>` (`None` for the CPU
-/// backend, which holds no setups, and for base-only targets; only matches the wrapper
-/// when the configured security level equals the wrapper's active security model) and
-/// prefer it over this function at startup. Keep this function as the CPU fallback, the
-/// wrapper-side ground truth for the identity test, and the only GPU-free derivation.
+/// TODO: with the next non-rc airbender + zkos-wrapper tag pair, expose this from
+/// `ProgramProver` instead — the GPU prover already derives it at construction
+/// (`UnrolledProver::level_data[RecursionUnrolled].hash_chain`; the unrolled level, not
+/// unified, which folds one layer too far). Keep this function as the CPU/GPU-free
+/// fallback and the identity test's ground truth.
 pub fn compute_program_commitment(binary_path: &Path) -> anyhow::Result<ProgramCommitment> {
     let source = ProgramSource::from_paths(
         binary_path
@@ -179,10 +166,8 @@ pub async fn run(args: Args) -> anyhow::Result<()> {
         .app_bin_path
         .unwrap_or_else(|| Path::new(&manifest_path).join("../../multiblock_batch.bin"));
 
-    // Fail fast on a binary none of the supported versions proves: such a deployment
-    // could only produce proofs the settlement side rejects (the SNARK VK does not
-    // cover the app binary; this commitment, carried through the recursion chain, is
-    // what gets checked downstream).
+    // Fail fast on a binary no supported version proves — its proofs could only be
+    // rejected at settlement.
     let program_commitment = compute_program_commitment(&binary_path)?;
     tracing::info!("App program commitment: {program_commitment}");
     anyhow::ensure!(
@@ -297,9 +282,8 @@ pub async fn run_inner(
                 );
                 return Ok(false);
             }
-            // The job's version must prove the program this prover has loaded — a
-            // mismatched proof would only be rejected downstream, after the GPU time
-            // is already spent.
+            // The job's version must prove the loaded program — a mismatched proof
+            // would be rejected downstream, after the GPU time is spent.
             let expected = supported_versions.program_commitment_for(&fri_job_input.vk_hash);
             if expected != Some(*program_commitment) {
                 tracing::error!(

--- a/crates/zksync_os_fri_prover/src/lib.rs
+++ b/crates/zksync_os_fri_prover/src/lib.rs
@@ -7,7 +7,7 @@ use anyhow::Context as _;
 use base64::{engine::general_purpose::STANDARD, Engine as _};
 
 use clap::Parser;
-use protocol_version::SupportedProtocolVersions;
+use protocol_version::{ProgramCommitment, SupportedProtocolVersions};
 use tracing_subscriber::{EnvFilter, FmtSubscriber};
 use zksync_airbender_cli::prover_utils::{
     serialize_to_file, ProgramProver, ProgramProverConfig, ProgramSource, ProofTarget,
@@ -97,6 +97,37 @@ pub fn create_prover(binary_path: &Path) -> anyhow::Result<ProgramProver> {
     ProgramProver::new(source, config).map_err(|e| anyhow::anyhow!("failed to create prover: {e}"))
 }
 
+/// Compute the chain commitment of the app program at `binary_path` (`.text` sibling
+/// derived like [`create_prover`] does).
+///
+/// This is the blake2s recursion-chain value — the base program's `end_params` folded
+/// with the unrolled recursion verifier's — that proofs of this program expose in their
+/// final registers 18..=25 and that the settlement side checks the SNARK public input
+/// against. Since V8 the SNARK VK no longer covers the app binary, so the
+/// (vk_hash, program commitment) pair is what identifies a protocol version end to end;
+/// comparing this value against the [`SupportedProtocolVersions`] table catches a
+/// "right prover stack, wrong binary" deployment before any proving starts.
+///
+/// Derived with zkos-wrapper's own `BinaryCommitment` so the value is byte-identical to
+/// what the wrapper chain enforces. Note this recomputes the program's setup caps
+/// (the prover's own copy in [`create_prover`] is not accessible), which takes on the
+/// order of a minute — call it once at startup.
+pub fn compute_program_commitment(binary_path: &Path) -> anyhow::Result<ProgramCommitment> {
+    let source = ProgramSource::from_paths(
+        binary_path
+            .to_str()
+            .with_context(|| format!("non-UTF8 binary path {binary_path:?}"))?
+            .to_string(),
+        None,
+    );
+    let bin = std::fs::read(&source.bin_path)
+        .with_context(|| format!("failed to read program binary {}", source.bin_path))?;
+    let text = std::fs::read(&source.text_path)
+        .with_context(|| format!("failed to read program text section {}", source.text_path))?;
+    let commitment = zkos_wrapper::circuits::BinaryCommitment::from_base_binary(&bin, &text);
+    Ok(ProgramCommitment(commitment.aux_params))
+}
+
 pub fn create_proof(
     prover: &ProgramProver,
     batch_id: u64,
@@ -137,6 +168,19 @@ pub async fn run(args: Args) -> anyhow::Result<()> {
     let binary_path = args
         .app_bin_path
         .unwrap_or_else(|| Path::new(&manifest_path).join("../../multiblock_batch.bin"));
+
+    // Fail fast on a binary none of the supported versions proves: such a deployment
+    // could only produce proofs the settlement side rejects (the SNARK VK does not
+    // cover the app binary; this commitment, carried through the recursion chain, is
+    // what gets checked downstream).
+    let program_commitment = compute_program_commitment(&binary_path)?;
+    tracing::info!("App program commitment: {program_commitment}");
+    anyhow::ensure!(
+        supported_versions.supports_program(&program_commitment),
+        "program {binary_path:?} (commitment {program_commitment}) is not proven by any \
+         supported protocol version"
+    );
+
     let prover = create_prover(&binary_path)?;
 
     tracing::info!(
@@ -161,6 +205,7 @@ pub async fn run(args: Args) -> anyhow::Result<()> {
             &prover,
             args.path.clone(),
             &supported_versions,
+            &program_commitment,
         )
         .await
         .expect("Failed to run FRI prover");
@@ -204,6 +249,7 @@ pub async fn run_inner(
     prover: &ProgramProver,
     path: Option<PathBuf>,
     supported_versions: &SupportedProtocolVersions,
+    program_commitment: &ProgramCommitment,
 ) -> anyhow::Result<bool> {
     let FriJobInputs {
         batch_number,
@@ -238,6 +284,22 @@ pub async fn run_inner(
                     fri_job_input.vk_hash,
                     fri_job_input.batch_number,
                     client.sequencer_url()
+                );
+                return Ok(false);
+            }
+            // The job's version must prove the program this prover has loaded — a
+            // mismatched proof would only be rejected downstream, after the GPU time
+            // is already spent.
+            let expected = supported_versions.program_commitment_for(&fri_job_input.vk_hash);
+            if expected != Some(*program_commitment) {
+                tracing::error!(
+                    "Protocol version with vk_hash {} for batch number {} from sequencer {} \
+                     proves a different app program (version's commitment: {}, loaded binary: \
+                     {program_commitment})",
+                    fri_job_input.vk_hash,
+                    fri_job_input.batch_number,
+                    client.sequencer_url(),
+                    expected.map_or_else(|| "none".to_string(), |c| c.to_string()),
                 );
                 return Ok(false);
             }

--- a/crates/zksync_os_fri_prover/src/lib.rs
+++ b/crates/zksync_os_fri_prover/src/lib.rs
@@ -112,6 +112,16 @@ pub fn create_prover(binary_path: &Path) -> anyhow::Result<ProgramProver> {
 /// what the wrapper chain enforces. Note this recomputes the program's setup caps
 /// (the prover's own copy in [`create_prover`] is not accessible), which takes on the
 /// order of a minute — call it once at startup.
+///
+/// TODO: the GPU prover already computes this exact value at construction —
+/// airbender's `UnrolledProver::level_data[RecursionUnrolled].hash_chain` is this chain
+/// (the unified level's is one fold too far); only `ProgramProver`'s private `inner`
+/// field keeps it out of reach. When cutting the next airbender + zkos-wrapper tag pair
+/// (non-rc), add an accessor upstream returning `Option<[u32; 8]>` (`None` for the CPU
+/// backend, which holds no setups, and for base-only targets; only matches the wrapper
+/// when the configured security level equals the wrapper's active security model) and
+/// prefer it over this function at startup. Keep this function as the CPU fallback, the
+/// wrapper-side ground truth for the identity test, and the only GPU-free derivation.
 pub fn compute_program_commitment(binary_path: &Path) -> anyhow::Result<ProgramCommitment> {
     let source = ProgramSource::from_paths(
         binary_path

--- a/crates/zksync_os_fri_prover/tests/program_commitment.rs
+++ b/crates/zksync_os_fri_prover/tests/program_commitment.rs
@@ -1,0 +1,34 @@
+use protocol_version::SupportedProtocolVersions;
+use std::path::Path;
+
+/// Pins the `program_commitment` values recorded in `protocol_version` to the actual
+/// `multiblock_batch.bin`/`.text` pair shipped in this repo.
+///
+/// Ignored by default: deriving the commitment recomputes the program's setup caps,
+/// which takes minutes in debug builds. Run it (in release) whenever the app binary or
+/// the airbender/zkos-wrapper pins change:
+///
+/// ```bash
+/// cargo test -p zksync_os_fri_prover --release -- --ignored program_commitment
+/// ```
+#[test]
+#[ignore = "recomputes program setup caps (minutes in debug); run in release when bumping the binary or pins"]
+fn recorded_program_commitment_matches_repo_binary() {
+    let binary_path = Path::new(env!("CARGO_MANIFEST_DIR")).join("../../multiblock_batch.bin");
+    let computed = zksync_os_fri_prover::compute_program_commitment(&binary_path)
+        .expect("failed to compute program commitment");
+
+    let versions = SupportedProtocolVersions::default();
+    let vk_hashes = versions.vk_hashes();
+    assert!(!vk_hashes.is_empty(), "no supported protocol versions");
+    for vk_hash in &vk_hashes {
+        let recorded = versions
+            .program_commitment_for(vk_hash)
+            .unwrap_or_else(|| panic!("no program commitment recorded for vk_hash {vk_hash}"));
+        assert_eq!(
+            recorded, computed,
+            "program commitment recorded for vk_hash {vk_hash} ({recorded}) does not match \
+             the repo's multiblock_batch.bin ({computed})"
+        );
+    }
+}

--- a/crates/zksync_os_fri_prover/tests/program_commitment.rs
+++ b/crates/zksync_os_fri_prover/tests/program_commitment.rs
@@ -1,12 +1,8 @@
 use protocol_version::SupportedProtocolVersions;
 use std::path::Path;
 
-/// Pins the `program_commitment` values recorded in `protocol_version` to the actual
-/// `multiblock_batch.bin`/`.text` pair shipped in this repo.
-///
-/// Ignored by default: deriving the commitment recomputes the program's setup caps,
-/// which takes minutes in debug builds. Run it (in release) whenever the app binary or
-/// the airbender/zkos-wrapper pins change:
+/// Pins the recorded `program_commitment` values to the repo's `multiblock_batch.bin`.
+/// Run when bumping the binary or the airbender/zkos-wrapper pins:
 ///
 /// ```bash
 /// cargo test -p zksync_os_fri_prover --release -- --ignored program_commitment

--- a/crates/zksync_os_prover_service/src/lib.rs
+++ b/crates/zksync_os_prover_service/src/lib.rs
@@ -127,8 +127,8 @@ pub async fn run(args: Args) -> anyhow::Result<()> {
         .app_bin_path
         .unwrap_or_else(|| Path::new(&manifest_path).join("../../multiblock_batch.bin"));
 
-    // Fail fast on a binary none of the supported versions proves — its proofs could
-    // only be rejected downstream (the SNARK VK does not cover the app binary).
+    // Fail fast on a binary no supported version proves — its proofs could only be
+    // rejected at settlement.
     let program_commitment = zksync_os_fri_prover::compute_program_commitment(&binary_path)?;
     tracing::info!("App program commitment: {program_commitment}");
     anyhow::ensure!(

--- a/crates/zksync_os_prover_service/src/lib.rs
+++ b/crates/zksync_os_prover_service/src/lib.rs
@@ -127,6 +127,16 @@ pub async fn run(args: Args) -> anyhow::Result<()> {
         .app_bin_path
         .unwrap_or_else(|| Path::new(&manifest_path).join("../../multiblock_batch.bin"));
 
+    // Fail fast on a binary none of the supported versions proves — its proofs could
+    // only be rejected downstream (the SNARK VK does not cover the app binary).
+    let program_commitment = zksync_os_fri_prover::compute_program_commitment(&binary_path)?;
+    tracing::info!("App program commitment: {program_commitment}");
+    anyhow::ensure!(
+        supported_versions.supports_program(&program_commitment),
+        "program {binary_path:?} (commitment {program_commitment}) is not proven by any \
+         supported protocol version"
+    );
+
     // The FRI prover and the FRI-proof combiner each size their device pool to "all
     // free VRAM" and need essentially the whole card (on prod-shaped L4s a resident
     // SNARK wrapper starves the FRI prover into OOM). So the wrapper is built per
@@ -169,6 +179,7 @@ pub async fn run(args: Args) -> anyhow::Result<()> {
                 &fri_prover,
                 args.fri_path.clone(),
                 &supported_versions,
+                &program_commitment,
             )
             .await
             .expect("Failed to run FRI prover");

--- a/crates/zksync_os_snark_prover/src/lib.rs
+++ b/crates/zksync_os_snark_prover/src/lib.rs
@@ -1,4 +1,4 @@
-use protocol_version::SupportedProtocolVersions;
+use protocol_version::{ProgramCommitment, SupportedProtocolVersions};
 use std::path::Path;
 use std::time::{Duration, Instant};
 use tracing_subscriber::{EnvFilter, FmtSubscriber};
@@ -89,6 +89,23 @@ pub fn create_snark_wrapper_with_cache(
     }
 
     Ok(wrapper)
+}
+
+/// The app-program chain commitment a FRI proof carries in its final registers 18..=25.
+///
+/// This is the value the settlement side compares the SNARK public input against (the
+/// SNARK VK itself does not cover the app binary), so checking it against the protocol
+/// version's recorded commitment up front rejects proofs of the wrong program before
+/// the wrap chain spends GPU time on them. Combined (multi-batch) proofs carry the same
+/// shared chain in the same registers. Note the proof's `recursion_chain_hash` field is
+/// NOT this value — that is the prover-internal recursion-layer chain, which varies
+/// with the number of unified passes.
+fn carried_program_commitment(proof: &UnrolledProgramProof) -> ProgramCommitment {
+    let mut words = [0u32; 8];
+    for (i, word) in words.iter_mut().enumerate() {
+        *word = proof.register_final_values[18 + i].value;
+    }
+    ProgramCommitment(words)
 }
 
 /// Build the FRI-proof combiner used by [`merge_fris`] for multi-proof jobs.
@@ -318,6 +335,28 @@ pub async fn run_inner(
                     client.sequencer_url()
                 );
                 return Ok(false);
+            }
+            // Every proof of the job must attest the app program its protocol version
+            // proves; a wrong-program proof would survive the whole wrap chain (the
+            // SNARK VK does not cover the app binary) only to be rejected downstream.
+            if let Some(expected) =
+                supported_protocol_versions.program_commitment_for(&snark_proof_input.vk_hash)
+            {
+                for (i, proof) in snark_proof_input.fri_proofs.iter().enumerate() {
+                    let carried = carried_program_commitment(proof);
+                    if carried != expected {
+                        tracing::error!(
+                            "FRI proof {i} of batches [{} to {}] from sequencer {} carries \
+                             program commitment {carried}, but protocol version {} proves \
+                             {expected}; skipping",
+                            snark_proof_input.from_batch_number.0,
+                            snark_proof_input.to_batch_number.0,
+                            client.sequencer_url(),
+                            snark_proof_input.vk_hash,
+                        );
+                        return Ok(false);
+                    }
+                }
             }
             snark_proof_input
         }

--- a/crates/zksync_os_snark_prover/src/lib.rs
+++ b/crates/zksync_os_snark_prover/src/lib.rs
@@ -91,15 +91,10 @@ pub fn create_snark_wrapper_with_cache(
     Ok(wrapper)
 }
 
-/// The app-program chain commitment a FRI proof carries in its final registers 18..=25.
-///
-/// This is the value the settlement side compares the SNARK public input against (the
-/// SNARK VK itself does not cover the app binary), so checking it against the protocol
-/// version's recorded commitment up front rejects proofs of the wrong program before
-/// the wrap chain spends GPU time on them. Combined (multi-batch) proofs carry the same
-/// shared chain in the same registers. Note the proof's `recursion_chain_hash` field is
-/// NOT this value — that is the prover-internal recursion-layer chain, which varies
-/// with the number of unified passes.
+/// The app-program chain commitment a FRI proof (combined multi-batch ones included)
+/// carries in its final registers 18..=25 — the value the settlement side checks the
+/// SNARK public input against. NOT the proof's `recursion_chain_hash`, which is the
+/// prover-internal layer chain and varies with the number of unified passes.
 fn carried_program_commitment(proof: &UnrolledProgramProof) -> ProgramCommitment {
     let mut words = [0u32; 8];
     for (i, word) in words.iter_mut().enumerate() {
@@ -336,9 +331,9 @@ pub async fn run_inner(
                 );
                 return Ok(false);
             }
-            // Every proof of the job must attest the app program its protocol version
-            // proves; a wrong-program proof would survive the whole wrap chain (the
-            // SNARK VK does not cover the app binary) only to be rejected downstream.
+            // Reject wrong-program proofs up front — they would survive the whole wrap
+            // chain (the SNARK VK does not cover the app binary) only to be rejected
+            // at settlement.
             if let Some(expected) =
                 supported_protocol_versions.program_commitment_for(&snark_proof_input.vk_hash)
             {


### PR DESCRIPTION
Since V8 the SNARK VK is app-independent: the app binary is bound through the blake2s recursion chain the proof carries (final registers 18..=25), checked against the expected program on the settlement side. vk_hash alone therefore no longer identifies the app binary — the (vk_hash, program commitment) pair does.

Record that commitment per protocol version and enforce the pairing in the prover fleet:

- protocol_version: ProgramCommitment ([u32; 8] chain value) recorded per version (V8 = the zksync-os 0.4.0 multiblock batch program), with program_commitment_for/supports_program lookups
- FRI prover + prover service: compute the loaded binary's commitment at startup (zkos-wrapper's BinaryCommitment::from_base_binary, so the value is byte-identical to what the wrapper chain enforces) and refuse to start if no supported version proves it; refuse jobs whose version proves a different program
- SNARK prover: refuse jobs whose FRI proofs carry a chain commitment other than the one recorded for the job's protocol version, before the wrap chain spends GPU time on them
- ignored release-mode test pinning the recorded V8 commitment to the repo's multiblock_batch.bin/.text (run when bumping the binary or pins)