### PR TITLE
chore: update the V8 app binary md5 for the post-#733 zksync-os STF

### DIFF
--- a/crates/protocol_version/src/lib.rs
+++ b/crates/protocol_version/src/lib.rs
@@ -105,7 +105,7 @@ const V8: ProtocolVersion = ProtocolVersion {
     airbender_version: AirbenderVersion("v0.6.0-rc.1"),
     zksync_os_version: ZkSyncOSVersion("v0.4.0"),
     zkos_wrapper: ZkOsWrapperVersion("v0.6.0-rc.1"),
-    bin_md5sum: BinMd5Sum("3e19df8c36564939950e0a079061ad1b"),
+    bin_md5sum: BinMd5Sum("8128c18a3b7145366b184e027d0e0f34"),
 };
 
 /// Represents the set of supported protocol versions by this prover implementation.


### PR DESCRIPTION
multiblock_batch.bin rebuilt reproducibly from zksync-os draft-0.4.0 @ 8ef47499 (airbender-platform v0.2.4 via matter-labs/zksync-os#733, plus the SHA3 charge-order and SAR saturation STF fixes). vk_hash is unchanged: the SNARK wraps the app-independent unified verifier, so the binary is bound via the recursion chain, not the VK.