### PR TITLE
fix: widen and simplify prover duration histogram buckets

### DIFF
--- a/crates/zksync_os_fri_prover/src/metrics.rs
+++ b/crates/zksync_os_fri_prover/src/metrics.rs
@@ -24,10 +24,15 @@ pub async fn start_metrics_exporter(
     Ok(())
 }
 
+const PROVING_LATENCIES: vise::Buckets = vise::Buckets::values(&[
+    0.01, 0.02, 0.05, 0.1, 0.2, 0.5, 1.0, 2.0, 5.0, 10.0, 20.0, 50.0, 100.0, 200.0, 500.0, 1000.0,
+    2000.0, 5000.0, 10_000.0,
+]);
+
 #[derive(Debug, Clone, Metrics)]
 #[metrics(prefix = "fri_prover")]
 pub struct FriProverMetrics {
-    #[metrics(buckets = vise::Buckets::linear(1.0..=5.0, 0.5), unit = vise::Unit::Seconds)]
+    #[metrics(buckets = PROVING_LATENCIES, unit = vise::Unit::Seconds)]
     pub time_taken: Histogram,
     pub latest_proven_batch: Gauge,
     /// Number of timeout errors when communicating with sequencer

--- a/crates/zksync_os_snark_prover/src/metrics.rs
+++ b/crates/zksync_os_snark_prover/src/metrics.rs
@@ -25,12 +25,17 @@ pub async fn start_metrics_exporter(
     Ok(())
 }
 
+const PROVING_LATENCIES: vise::Buckets = vise::Buckets::values(&[
+    0.01, 0.02, 0.05, 0.1, 0.2, 0.5, 1.0, 2.0, 5.0, 10.0, 20.0, 50.0, 100.0, 200.0, 500.0, 1000.0,
+    2000.0, 5000.0, 10_000.0,
+]);
+
 #[derive(Debug, Clone, Metrics)]
 #[metrics(prefix = "snark_prover")]
 pub struct SnarkProverMetrics {
     #[metrics(buckets = vise::Buckets::linear(50.0..=200.0, 25.0), unit = vise::Unit::Seconds)]
     pub time_taken_startup: Histogram,
-    #[metrics(buckets = vise::Buckets::linear(1.0..=150.0, 20.0), unit = vise::Unit::Seconds)]
+    #[metrics(buckets = PROVING_LATENCIES, unit = vise::Unit::Seconds)]
     pub time_taken_merge_fri: Histogram,
     /// Time spent building the per-job SNARK wrapper in the combined prover service,
     /// which drops the wrapper between jobs so it can't compete with the FRI prover
@@ -41,9 +46,9 @@ pub struct SnarkProverMetrics {
     pub time_taken_wrapper_setup: Histogram,
     #[metrics(buckets = vise::Buckets::linear(5.0..=20.0, 2.5), unit = vise::Unit::Seconds)]
     pub time_taken_final_proof: Histogram,
-    #[metrics(buckets = vise::Buckets::linear(50.0..=200.0, 25.0), unit = vise::Unit::Seconds)]
+    #[metrics(buckets = PROVING_LATENCIES, unit = vise::Unit::Seconds)]
     pub time_taken_snark: Histogram,
-    #[metrics(buckets = vise::Buckets::linear(50.0..=200.0, 25.0), unit = vise::Unit::Seconds)]
+    #[metrics(buckets = PROVING_LATENCIES, unit = vise::Unit::Seconds)]
     pub time_taken_full: Histogram,
     /// Time spent building the merge combiner's caches (unified-level setup and, on
     /// GPU builds, the prover host state). Observed only when a merge found them cold,


### PR DESCRIPTION
`fri_prover_time_taken` clipped at 5s and the SNARK duration histograms at 150–200s, so a fat batch (601s, measured 2026-08-07) and any backlog SNARK land in `+Inf` with quantiles saturated.

`fri_prover_time_taken` and `snark_prover_time_taken_{merge_fri,snark,full}` now share `PROVING_LATENCIES` (10ms..10 000s, 1‑2‑5 boundaries) — identical to the sequencer's `prover_prove_time_seconds` (companion PR [zksync-os-server#1505](https://github.com/matter-labs/zksync-os-server/pull/1505)) so both sides of a job are comparable.

Boundaries only, no renames. Startup, wrapper-setup and merge-warm-up are one-time per-process costs and left alone; `final_proof` (top 20s) is plausible for a sub-stage of a ~135s SNARK but wasn't checked against data.

Context: [PLA-1229](https://linear.app/matterlabs/issue/PLA-1229/increase-the-server-side-prover-job-timeouts) / [PLA-1209](https://linear.app/matterlabs/issue/PLA-1209/alert-p3-on-frisnark-proving-stall-batcher-vs-prover-queue-lag).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
