### PR TITLE
feat!: bind the app program into the SNARK VK via check_aux_params

### DIFF
--- a/crates/protocol_version/src/lib.rs
+++ b/crates/protocol_version/src/lib.rs
@@ -21,15 +21,19 @@ struct ProtocolVersion {
     /// NOTE2: this can be inferred from zksync_os_version, but we keep it here for easier cross-checking
     bin_md5sum: BinMd5Sum,
     /// Chain commitment of the app program this version proves (see [`ProgramCommitment`]).
-    /// Since V8 the SNARK VK is app-independent, so the (vk_hash, program_commitment)
-    /// pair is what identifies a version. `None` pre-V8 (VK covered the binary).
+    /// The SNARK wrapper bakes it into the VK (registers 18..=25 == aux_params, via
+    /// `check_aux_params`), so `vk_hash` alone identifies the app program again; this field
+    /// is the plaintext of that binding, used to reject wrong-program FRI proofs up front
+    /// and to re-derive/verify the VK. `None` pre-V8 (the VK already covered the binary).
     program_commitment: Option<ProgramCommitment>,
 }
 
-/// Blake2s recursion-chain commitment binding a protocol version to its app program:
-/// the base program's `end_params` folded with the unrolled recursion verifier's — the
-/// value proofs expose in final registers 18..=25 and the settlement side checks the
-/// SNARK public input against. See `zksync_os_fri_prover::compute_program_commitment`.
+/// Blake2s recursion-chain commitment binding a protocol version to its app program: the
+/// base program's `end_params` folded with the unrolled recursion verifier's — the value
+/// proofs expose in final registers 18..=25. The SNARK wrapper constrains those registers
+/// to this value in-circuit (`check_aux_params`), so the app program is bound through the
+/// VK rather than carried in the SNARK public input. See
+/// `zksync_os_fri_prover::compute_program_commitment`.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct ProgramCommitment(pub [u32; 8]);
 
@@ -124,6 +128,13 @@ const V7: ProtocolVersion = ProtocolVersion {
 };
 
 /// Corresponds to server's execution_version 8 (protocol v32.0, zksync-os 0.4.0 native batch prover)
+///
+/// TODO(vk-regen): the `vk_hash` below is the pre-`check_aux_params` value — that VK did
+/// not bind the app program. Enabling the VK-level binding (`check_aux_params = true`,
+/// see `zksync_os_snark_prover::create_snark_wrapper`) changes the VK, so this hash MUST
+/// be regenerated over `multiblock_batch.bin` and the new value re-registered on L1 and
+/// re-published by the sequencer before this version proves in production. `program_commitment`
+/// is unaffected (it is the value the new VK bakes in).
 const V8: ProtocolVersion = ProtocolVersion {
     vk_hash: VerificationKeyHash(
         "0x3e7784b0fdb09035a677ae80568d34fdb1f1ec6ac65bba5192cd977a4f0e7609",

--- a/crates/protocol_version/src/lib.rs
+++ b/crates/protocol_version/src/lib.rs
@@ -129,15 +129,18 @@ const V7: ProtocolVersion = ProtocolVersion {
 
 /// Corresponds to server's execution_version 8 (protocol v32.0, zksync-os 0.4.0 native batch prover)
 ///
-/// TODO(vk-regen): the `vk_hash` below is the pre-`check_aux_params` value — that VK did
-/// not bind the app program. Enabling the VK-level binding (`check_aux_params = true`,
-/// see `zksync_os_snark_prover::create_snark_wrapper`) changes the VK, so this hash MUST
-/// be regenerated over `multiblock_batch.bin` and the new value re-registered on L1 and
-/// re-published by the sequencer before this version proves in production. `program_commitment`
-/// is unaffected (it is the value the new VK bakes in).
+/// `vk_hash` is the `check_aux_params = true` VK, which binds the app program in-circuit
+/// (see `zksync_os_snark_prover::create_snark_wrapper`); regenerated over
+/// `multiblock_batch.bin` with `crs/setup_2^24.key`. The pre-`check_aux_params` value was
+/// `0x3e7784b0fdb09035a677ae80568d34fdb1f1ec6ac65bba5192cd977a4f0e7609`.
+///
+/// NOTE: this VK must still be adopted downstream before it proves in production — the
+/// sequencer must publish this hash in its job payloads, and the matching SNARK verifier
+/// (regenerated from the new `snark_vk.json`) redeployed and registered on L1
+/// (era-contracts). `program_commitment` is the value the VK bakes into registers 18..=25.
 const V8: ProtocolVersion = ProtocolVersion {
     vk_hash: VerificationKeyHash(
-        "0x3e7784b0fdb09035a677ae80568d34fdb1f1ec6ac65bba5192cd977a4f0e7609",
+        "0xf89183f266d570b6a0119da65348bcb068fb858835fb3f49e2176b4e15048bcc",
     ),
     airbender_version: AirbenderVersion("v0.6.0-rc.1"),
     zksync_os_version: ZkSyncOSVersion("v0.4.0"),

--- a/crates/zksync_os_prover_service/src/lib.rs
+++ b/crates/zksync_os_prover_service/src/lib.rs
@@ -147,6 +147,7 @@ pub async fn run(args: Args) -> anyhow::Result<()> {
     // the retry closure below can borrow it mutably.
     let wrapper_source = RefCell::new(zksync_os_snark_prover::WrapperSource::PerJob {
         trusted_setup_file: args.trusted_setup_file.clone(),
+        app_bin_path: binary_path.clone(),
         host_cache: None,
     });
 

--- a/crates/zksync_os_snark_prover/src/lib.rs
+++ b/crates/zksync_os_snark_prover/src/lib.rs
@@ -1,5 +1,6 @@
+use anyhow::Context as _;
 use protocol_version::{ProgramCommitment, SupportedProtocolVersions};
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::time::{Duration, Instant};
 use tracing_subscriber::{EnvFilter, FmtSubscriber};
 use zkos_wrapper::{
@@ -10,8 +11,8 @@ use zksync_airbender_cli::prover_utils::CpuConfig;
 #[cfg(feature = "gpu")]
 use zksync_airbender_cli::prover_utils::GpuConfig;
 use zksync_airbender_cli::prover_utils::{
-    CarriedChainCombiner, ProgramProverConfig, ProofArtifact, ProofCounts, ProofTarget,
-    ProofTimingsMs, ProverBackend,
+    CarriedChainCombiner, ProgramProverConfig, ProgramSource, ProofArtifact, ProofCounts,
+    ProofTarget, ProofTimingsMs, ProverBackend,
 };
 use zksync_airbender_execution_utils::unrolled::UnrolledProgramProof;
 use zksync_sequencer_proof_client::{ProofClient, SnarkProofInputs};
@@ -44,6 +45,10 @@ pub enum WrapperSource {
     /// rebuild the wrapper from the cache in negligible time.
     PerJob {
         trusted_setup_file: String,
+        /// App binary whose commitment is bound into the wrapper VK via
+        /// `check_aux_params` (see [`create_snark_wrapper`]). Only consumed on the
+        /// cache-less first build; later builds restore it from `host_cache`.
+        app_bin_path: PathBuf,
         /// Setup caches carried between jobs; `None` until the first job's wrapper is
         /// retired. Holds no GPU memory (see [`SnarkWrapperHostCache`]).
         host_cache: Option<Box<SnarkWrapperHostCache>>,
@@ -52,29 +57,39 @@ pub enum WrapperSource {
 
 /// Build the SNARK wrapper session used for proving and VK generation.
 ///
-/// The wrapper is constructed without an explicit binary: the verification keys bind the
-/// wrapper chain over zkos-wrapper's embedded unified recursion verifier binary, and the
-/// app binary is bound through the recursion chain carried inside the FRI proof itself.
-pub fn create_snark_wrapper(trusted_setup_file: String) -> anyhow::Result<SnarkWrapper> {
-    create_snark_wrapper_with_cache(trusted_setup_file, None)
+/// The wrapper runs with `check_aux_params` enabled, which binds the app program into the
+/// verification key: the RISC-wrapper circuit constrains the FRI proof's final registers
+/// 18..=25 (the blake2s recursion-chain commitment of the app binary) to the `aux_params`
+/// derived from `app_bin_path`, and takes the settlement public input directly from
+/// registers 10..=16. A FRI proof of any other program then fails the in-circuit check
+/// instead of producing a wrappable proof, so a wrong-program proof can no longer be
+/// wrapped into a valid SNARK.
+///
+/// Because the commitment is a circuit constant, the VK is app-specific: it must be
+/// regenerated — and the new hash re-registered on L1 and re-published by the sequencer —
+/// whenever the app binary changes.
+pub fn create_snark_wrapper(
+    trusted_setup_file: String,
+    app_bin_path: &Path,
+) -> anyhow::Result<SnarkWrapper> {
+    create_snark_wrapper_with_cache(trusted_setup_file, app_bin_path, None)
 }
 
 /// Like [`create_snark_wrapper`], but adopt the setup caches of a retired wrapper
 /// (see [`SnarkWrapper::into_host_cache`]) so the chain derivation is skipped.
 ///
 /// The cache carries the retired session's whole configuration, including its trusted
-/// setup path, so `trusted_setup_file` only applies to cache-less (first) builds.
+/// setup path and bound app binary, so `trusted_setup_file` and `app_bin_path` only apply
+/// to cache-less (first) builds.
 pub fn create_snark_wrapper_with_cache(
     trusted_setup_file: String,
+    app_bin_path: &Path,
     host_cache: Option<SnarkWrapperHostCache>,
 ) -> anyhow::Result<SnarkWrapper> {
     #[cfg_attr(not(feature = "gpu"), allow(unused_mut))]
     let mut wrapper = match host_cache {
         Some(cache) => SnarkWrapper::from_host_cache(cache)?,
-        None => SnarkWrapper::new(SnarkWrapperConfig {
-            trusted_setup: Some(trusted_setup_file.into()),
-            ..Default::default()
-        })?,
+        None => SnarkWrapper::new(build_wrapper_config(trusted_setup_file, app_bin_path)?)?,
     };
 
     // Mirror the old eager GPU precomputation: derive the full VK/setup chain up front so
@@ -89,6 +104,35 @@ pub fn create_snark_wrapper_with_cache(
     }
 
     Ok(wrapper)
+}
+
+/// Build the wrapper config that binds the app program at `app_bin_path` into the VK via
+/// `check_aux_params`.
+///
+/// The `.text` section path is derived from the `.bin` path exactly as the FRI prover does
+/// ([`ProgramSource::from_paths`]), so the `aux_params` the wrapper bakes in are computed
+/// over the same binary the FRI proof executed and match the commitment it carries in
+/// registers 18..=25.
+fn build_wrapper_config(
+    trusted_setup_file: String,
+    app_bin_path: &Path,
+) -> anyhow::Result<SnarkWrapperConfig> {
+    let bin_path = app_bin_path
+        .to_str()
+        .with_context(|| format!("non-UTF8 app binary path {app_bin_path:?}"))?
+        .to_string();
+    let source = ProgramSource::from_paths(bin_path, None);
+    // Fail fast on a missing binary/text instead of erroring deep in VK derivation.
+    for path in [&source.bin_path, &source.text_path] {
+        anyhow::ensure!(Path::new(path).is_file(), "program file not found: {path}");
+    }
+    Ok(SnarkWrapperConfig {
+        trusted_setup: Some(trusted_setup_file.into()),
+        bin: Some(source.bin_path.into()),
+        text: Some(source.text_path.into()),
+        check_aux_params: true,
+        ..Default::default()
+    })
 }
 
 /// The app-program chain commitment a FRI proof (combined multi-batch ones included)
@@ -238,6 +282,7 @@ pub async fn run_linking_fri_snark(
     clients: Vec<Box<dyn ProofClient + Send + Sync>>,
     output_dir: String,
     trusted_setup_file: String,
+    app_bin_path: PathBuf,
     iterations: Option<usize>,
     disable_zk: bool,
 ) -> anyhow::Result<()> {
@@ -254,8 +299,10 @@ pub async fn run_linking_fri_snark(
     let supported_versions = SupportedProtocolVersions::default();
     tracing::info!("{:#?}", supported_versions);
 
-    let mut wrapper_source =
-        WrapperSource::Resident(Box::new(create_snark_wrapper(trusted_setup_file)?));
+    let mut wrapper_source = WrapperSource::Resident(Box::new(create_snark_wrapper(
+        trusted_setup_file,
+        &app_bin_path,
+    )?));
 
     // Warm the combiner eagerly, mirroring the SNARK precomputation above: setup
     // problems surface at startup and the first multi-proof job doesn't pay for it.
@@ -331,9 +378,10 @@ pub async fn run_inner(
                 );
                 return Ok(false);
             }
-            // Reject wrong-program proofs up front — they would survive the whole wrap
-            // chain (the SNARK VK does not cover the app binary) only to be rejected
-            // at settlement.
+            // Reject wrong-program proofs up front with a clear error. The wrapper VK now
+            // binds the app program (check_aux_params constrains registers 18..=25 to the
+            // version's commitment), so such a proof would otherwise fail deep in wrap
+            // proving as an unsatisfiable circuit, after the GPU time is already spent.
             if let Some(expected) =
                 supported_protocol_versions.program_commitment_for(&snark_proof_input.vk_hash)
             {
@@ -414,12 +462,13 @@ pub async fn run_inner(
         WrapperSource::Resident(wrapper) => wrapper,
         WrapperSource::PerJob {
             trusted_setup_file,
+            app_bin_path,
             host_cache,
         } => {
             tracing::info!("Building per-job SNARK wrapper");
             let cache = host_cache.take().map(|cache| *cache);
             per_job_wrapper = Some(stats.measure_step(SnarkStage::WrapperSetup, || {
-                create_snark_wrapper_with_cache(trusted_setup_file.clone(), cache)
+                create_snark_wrapper_with_cache(trusted_setup_file.clone(), app_bin_path, cache)
             })?);
             per_job_wrapper.as_mut().expect("wrapper was just built")
         }

--- a/crates/zksync_os_snark_prover/src/main.rs
+++ b/crates/zksync_os_snark_prover/src/main.rs
@@ -1,3 +1,4 @@
+use std::path::{Path, PathBuf};
 use std::time::Duration;
 
 use clap::{Parser, Subcommand};
@@ -45,6 +46,11 @@ enum Commands {
         sequencer_urls: Vec<SequencerEndpoint>,
         #[clap(flatten)]
         setup: SetupOptions,
+        /// Path to `app.bin` bound into the SNARK VK (its `.text` sibling is derived).
+        /// Must be the same binary the FRI provers run. Defaults to the repo's
+        /// `multiblock_batch.bin`.
+        #[arg(long)]
+        app_bin_path: Option<PathBuf>,
         /// Number of iterations before exiting. Only successfully generated proofs count. If not specified, runs indefinitely
         #[arg(long)]
         iterations: Option<usize>,
@@ -90,12 +96,18 @@ fn main() -> anyhow::Result<()> {
                     output_dir,
                     trusted_setup_file,
                 },
+            app_bin_path,
             iterations,
             prometheus_port,
             request_timeout_secs,
             disable_zk,
             prover_name,
         } => {
+            // Default to the repo's app binary, mirroring the FRI prover / prover service.
+            let manifest_path =
+                std::env::var("CARGO_MANIFEST_DIR").unwrap_or_else(|_| ".".to_string());
+            let app_bin_path = app_bin_path
+                .unwrap_or_else(|| Path::new(&manifest_path).join("../../multiblock_batch.bin"));
             let (stop_sender, stop_receiver) = watch::channel(false);
 
             runtime.block_on(async move {
@@ -133,6 +145,7 @@ fn main() -> anyhow::Result<()> {
                         clients,
                         output_dir,
                         trusted_setup_file,
+                        app_bin_path,
                         iterations,
                         disable_zk,
                     ))


### PR DESCRIPTION
Run the SNARK wrapper in check_aux_params mode so the RISC-wrapper circuit constrains the FRI proof's final registers 18..=25 (the app program's blake2s recursion-chain commitment) to the aux_params baked in as a circuit constant, and takes the settlement public input from registers 10..=16 directly instead of keccak(registers 10..=25). This makes the VK app-specific: a FRI proof of any other program fails the in-circuit check rather than producing a wrappable proof, so a wrong-program FRI can no longer be wrapped into a valid SNARK. Previously the app program was bound nowhere the settlement path enforces (era-contracts draft-v32 checks only keccak(prevState || curState || batchCommitment)), leaving the off-chain register checks as the only guardrail.

Wiring:
- create_snark_wrapper / create_snark_wrapper_with_cache take app_bin_path and build SnarkWrapperConfig { bin, text, check_aux_params: true }; the .text path is derived via ProgramSource::from_paths so the SNARK side computes the same aux_params the FRI proof carries.
- WrapperSource::PerJob carries app_bin_path (consumed on the cache-less build).
- Standalone snark_prover gains --app-bin-path (defaults to multiblock_batch.bin); prover_service passes its resolved binary_path.

check_aux_params is also the public-input-compatible mode: the base program writes keccak256(prevState || curState || batchCommitment) into registers 10..=17, which is exactly the sequencer's single-batch formula, whereas the prior FALSE default double-hashes and does not match.

Before deploying:
- Regenerate the V8 vk_hash under check mode (0x3e7784b0... is the pre-check value) and re-register on L1 / re-publish from the sequencer. program_commitment is unchanged. See the TODO(vk-regen) on protocol_version::V8.
- Verify the multi-batch path: combined recursion sets registers 10..=17 to a single keccak over concatenated per-batch outputs, while L1's multi-batch public input is an iterative shift-and-fold; these likely diverge for N>=2 and need reconciliation. Orthogonal to check_aux_params; single-batch matches.