### PR TITLE
revert(gpu): drop the adaptive FRI arena and the Low preset

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5,7 +5,7 @@ version = 4
 [[package]]
 name = "add_sub_lui_auipc_mop"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?rev=580ad92dec77a478ada40b4f2b85d6b868f46d2f#580ad92dec77a478ada40b4f2b85d6b868f46d2f"
+source = "git+https://github.com/matter-labs/zksync-airbender?rev=a409f7742fcfb1ecf987d95985eced3a68f53f51#a409f7742fcfb1ecf987d95985eced3a68f53f51"
 dependencies = [
  "common_constants",
  "prover",
@@ -17,7 +17,7 @@ dependencies = [
 [[package]]
 name = "add_sub_lui_auipc_mop_verifier"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?rev=580ad92dec77a478ada40b4f2b85d6b868f46d2f#580ad92dec77a478ada40b4f2b85d6b868f46d2f"
+source = "git+https://github.com/matter-labs/zksync-airbender?rev=a409f7742fcfb1ecf987d95985eced3a68f53f51#a409f7742fcfb1ecf987d95985eced3a68f53f51"
 dependencies = [
  "field",
  "unroll",
@@ -521,7 +521,7 @@ checksum = "55248b47b0caf0546f7988906588779981c43bb1bc9d0c44087278f80cdb44ba"
 [[package]]
 name = "bigint_with_control"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?rev=580ad92dec77a478ada40b4f2b85d6b868f46d2f#580ad92dec77a478ada40b4f2b85d6b868f46d2f"
+source = "git+https://github.com/matter-labs/zksync-airbender?rev=a409f7742fcfb1ecf987d95985eced3a68f53f51#a409f7742fcfb1ecf987d95985eced3a68f53f51"
 dependencies = [
  "common_constants",
  "prover",
@@ -533,7 +533,7 @@ dependencies = [
 [[package]]
 name = "bigint_with_control_verifier"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?rev=580ad92dec77a478ada40b4f2b85d6b868f46d2f#580ad92dec77a478ada40b4f2b85d6b868f46d2f"
+source = "git+https://github.com/matter-labs/zksync-airbender?rev=a409f7742fcfb1ecf987d95985eced3a68f53f51#a409f7742fcfb1ecf987d95985eced3a68f53f51"
 dependencies = [
  "field",
  "unroll",
@@ -630,7 +630,7 @@ dependencies = [
 [[package]]
 name = "blake2_with_compression"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?rev=580ad92dec77a478ada40b4f2b85d6b868f46d2f#580ad92dec77a478ada40b4f2b85d6b868f46d2f"
+source = "git+https://github.com/matter-labs/zksync-airbender?rev=a409f7742fcfb1ecf987d95985eced3a68f53f51#a409f7742fcfb1ecf987d95985eced3a68f53f51"
 dependencies = [
  "common_constants",
  "prover",
@@ -642,7 +642,7 @@ dependencies = [
 [[package]]
 name = "blake2_with_compression_verifier"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?rev=580ad92dec77a478ada40b4f2b85d6b868f46d2f#580ad92dec77a478ada40b4f2b85d6b868f46d2f"
+source = "git+https://github.com/matter-labs/zksync-airbender?rev=a409f7742fcfb1ecf987d95985eced3a68f53f51#a409f7742fcfb1ecf987d95985eced3a68f53f51"
 dependencies = [
  "field",
  "unroll",
@@ -663,7 +663,7 @@ dependencies = [
 [[package]]
 name = "blake2s_u32"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?rev=580ad92dec77a478ada40b4f2b85d6b868f46d2f#580ad92dec77a478ada40b4f2b85d6b868f46d2f"
+source = "git+https://github.com/matter-labs/zksync-airbender?rev=a409f7742fcfb1ecf987d95985eced3a68f53f51#a409f7742fcfb1ecf987d95985eced3a68f53f51"
 dependencies = [
  "common_constants",
  "unroll",
@@ -846,7 +846,7 @@ dependencies = [
 [[package]]
 name = "circuit_mersenne_field"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zkos-wrapper.git?rev=024350a3f9ded2e3c43be6153921034c7c80455d#024350a3f9ded2e3c43be6153921034c7c80455d"
+source = "git+https://github.com/matter-labs/zkos-wrapper.git?rev=0f815df44c1379ee768b392bf85a90a43e22472e#0f815df44c1379ee768b392bf85a90a43e22472e"
 dependencies = [
  "boojum",
  "field",
@@ -896,7 +896,7 @@ checksum = "b94f61472cee1439c0b966b47e3aca9ae07e45d070759512cd390ea2bebc6675"
 [[package]]
 name = "cli"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?rev=580ad92dec77a478ada40b4f2b85d6b868f46d2f#580ad92dec77a478ada40b4f2b85d6b868f46d2f"
+source = "git+https://github.com/matter-labs/zksync-airbender?rev=a409f7742fcfb1ecf987d95985eced3a68f53f51#a409f7742fcfb1ecf987d95985eced3a68f53f51"
 dependencies = [
  "base64 0.21.7",
  "blake2s_u32",
@@ -937,7 +937,7 @@ checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
 [[package]]
 name = "common_constants"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?rev=580ad92dec77a478ada40b4f2b85d6b868f46d2f#580ad92dec77a478ada40b4f2b85d6b868f46d2f"
+source = "git+https://github.com/matter-labs/zksync-airbender?rev=a409f7742fcfb1ecf987d95985eced3a68f53f51#a409f7742fcfb1ecf987d95985eced3a68f53f51"
 dependencies = [
  "seq-macro",
 ]
@@ -1111,7 +1111,7 @@ dependencies = [
 [[package]]
 name = "cs"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?rev=580ad92dec77a478ada40b4f2b85d6b868f46d2f#580ad92dec77a478ada40b4f2b85d6b868f46d2f"
+source = "git+https://github.com/matter-labs/zksync-airbender?rev=a409f7742fcfb1ecf987d95985eced3a68f53f51#a409f7742fcfb1ecf987d95985eced3a68f53f51"
 dependencies = [
  "bincode 1.3.3",
  "blake2s_u32",
@@ -1439,7 +1439,7 @@ dependencies = [
 [[package]]
 name = "execution_utils"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?rev=580ad92dec77a478ada40b4f2b85d6b868f46d2f#580ad92dec77a478ada40b4f2b85d6b868f46d2f"
+source = "git+https://github.com/matter-labs/zksync-airbender?rev=a409f7742fcfb1ecf987d95985eced3a68f53f51#a409f7742fcfb1ecf987d95985eced3a68f53f51"
 dependencies = [
  "clap",
  "full_statement_verifier",
@@ -1532,7 +1532,7 @@ dependencies = [
 [[package]]
 name = "fft"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?rev=580ad92dec77a478ada40b4f2b85d6b868f46d2f#580ad92dec77a478ada40b4f2b85d6b868f46d2f"
+source = "git+https://github.com/matter-labs/zksync-airbender?rev=a409f7742fcfb1ecf987d95985eced3a68f53f51#a409f7742fcfb1ecf987d95985eced3a68f53f51"
 dependencies = [
  "field",
  "seq-macro",
@@ -1545,7 +1545,7 @@ dependencies = [
 [[package]]
 name = "field"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?rev=580ad92dec77a478ada40b4f2b85d6b868f46d2f#580ad92dec77a478ada40b4f2b85d6b868f46d2f"
+source = "git+https://github.com/matter-labs/zksync-airbender?rev=a409f7742fcfb1ecf987d95985eced3a68f53f51#a409f7742fcfb1ecf987d95985eced3a68f53f51"
 dependencies = [
  "rand 0.9.4",
  "seq-macro",
@@ -1643,7 +1643,7 @@ dependencies = [
 [[package]]
 name = "full_statement_verifier"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?rev=580ad92dec77a478ada40b4f2b85d6b868f46d2f#580ad92dec77a478ada40b4f2b85d6b868f46d2f"
+source = "git+https://github.com/matter-labs/zksync-airbender?rev=a409f7742fcfb1ecf987d95985eced3a68f53f51#a409f7742fcfb1ecf987d95985eced3a68f53f51"
 dependencies = [
  "add_sub_lui_auipc_mop_verifier",
  "bigint_with_control_verifier",
@@ -1812,7 +1812,7 @@ checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
 [[package]]
 name = "gpu_prover"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?rev=580ad92dec77a478ada40b4f2b85d6b868f46d2f#580ad92dec77a478ada40b4f2b85d6b868f46d2f"
+source = "git+https://github.com/matter-labs/zksync-airbender?rev=a409f7742fcfb1ecf987d95985eced3a68f53f51#a409f7742fcfb1ecf987d95985eced3a68f53f51"
 dependencies = [
  "blake2s_u32",
  "cmake",
@@ -2242,7 +2242,7 @@ dependencies = [
 [[package]]
 name = "inits_and_teardowns"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?rev=580ad92dec77a478ada40b4f2b85d6b868f46d2f#580ad92dec77a478ada40b4f2b85d6b868f46d2f"
+source = "git+https://github.com/matter-labs/zksync-airbender?rev=a409f7742fcfb1ecf987d95985eced3a68f53f51#a409f7742fcfb1ecf987d95985eced3a68f53f51"
 dependencies = [
  "common_constants",
  "prover",
@@ -2254,7 +2254,7 @@ dependencies = [
 [[package]]
 name = "inits_and_teardowns_verifier"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?rev=580ad92dec77a478ada40b4f2b85d6b868f46d2f#580ad92dec77a478ada40b4f2b85d6b868f46d2f"
+source = "git+https://github.com/matter-labs/zksync-airbender?rev=a409f7742fcfb1ecf987d95985eced3a68f53f51#a409f7742fcfb1ecf987d95985eced3a68f53f51"
 dependencies = [
  "field",
  "unroll",
@@ -2364,7 +2364,7 @@ dependencies = [
 [[package]]
 name = "jump_branch_slt"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?rev=580ad92dec77a478ada40b4f2b85d6b868f46d2f#580ad92dec77a478ada40b4f2b85d6b868f46d2f"
+source = "git+https://github.com/matter-labs/zksync-airbender?rev=a409f7742fcfb1ecf987d95985eced3a68f53f51#a409f7742fcfb1ecf987d95985eced3a68f53f51"
 dependencies = [
  "common_constants",
  "prover",
@@ -2376,7 +2376,7 @@ dependencies = [
 [[package]]
 name = "jump_branch_slt_verifier"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?rev=580ad92dec77a478ada40b4f2b85d6b868f46d2f#580ad92dec77a478ada40b4f2b85d6b868f46d2f"
+source = "git+https://github.com/matter-labs/zksync-airbender?rev=a409f7742fcfb1ecf987d95985eced3a68f53f51#a409f7742fcfb1ecf987d95985eced3a68f53f51"
 dependencies = [
  "field",
  "unroll",
@@ -2409,7 +2409,7 @@ dependencies = [
 [[package]]
 name = "keccak_special5"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?rev=580ad92dec77a478ada40b4f2b85d6b868f46d2f#580ad92dec77a478ada40b4f2b85d6b868f46d2f"
+source = "git+https://github.com/matter-labs/zksync-airbender?rev=a409f7742fcfb1ecf987d95985eced3a68f53f51#a409f7742fcfb1ecf987d95985eced3a68f53f51"
 dependencies = [
  "common_constants",
  "prover",
@@ -2421,7 +2421,7 @@ dependencies = [
 [[package]]
 name = "keccak_special5_verifier"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?rev=580ad92dec77a478ada40b4f2b85d6b868f46d2f#580ad92dec77a478ada40b4f2b85d6b868f46d2f"
+source = "git+https://github.com/matter-labs/zksync-airbender?rev=a409f7742fcfb1ecf987d95985eced3a68f53f51#a409f7742fcfb1ecf987d95985eced3a68f53f51"
 dependencies = [
  "field",
  "unroll",
@@ -2461,7 +2461,7 @@ checksum = "241eaef5fd12c88705a01fc1066c48c4b36e0dd4377dcdc7ec3942cea7a69956"
 [[package]]
 name = "load_store_subword_only"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?rev=580ad92dec77a478ada40b4f2b85d6b868f46d2f#580ad92dec77a478ada40b4f2b85d6b868f46d2f"
+source = "git+https://github.com/matter-labs/zksync-airbender?rev=a409f7742fcfb1ecf987d95985eced3a68f53f51#a409f7742fcfb1ecf987d95985eced3a68f53f51"
 dependencies = [
  "common_constants",
  "prover",
@@ -2473,7 +2473,7 @@ dependencies = [
 [[package]]
 name = "load_store_subword_only_verifier"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?rev=580ad92dec77a478ada40b4f2b85d6b868f46d2f#580ad92dec77a478ada40b4f2b85d6b868f46d2f"
+source = "git+https://github.com/matter-labs/zksync-airbender?rev=a409f7742fcfb1ecf987d95985eced3a68f53f51#a409f7742fcfb1ecf987d95985eced3a68f53f51"
 dependencies = [
  "field",
  "unroll",
@@ -2483,7 +2483,7 @@ dependencies = [
 [[package]]
 name = "load_store_word_only"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?rev=580ad92dec77a478ada40b4f2b85d6b868f46d2f#580ad92dec77a478ada40b4f2b85d6b868f46d2f"
+source = "git+https://github.com/matter-labs/zksync-airbender?rev=a409f7742fcfb1ecf987d95985eced3a68f53f51#a409f7742fcfb1ecf987d95985eced3a68f53f51"
 dependencies = [
  "common_constants",
  "prover",
@@ -2495,7 +2495,7 @@ dependencies = [
 [[package]]
 name = "load_store_word_only_verifier"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?rev=580ad92dec77a478ada40b4f2b85d6b868f46d2f#580ad92dec77a478ada40b4f2b85d6b868f46d2f"
+source = "git+https://github.com/matter-labs/zksync-airbender?rev=a409f7742fcfb1ecf987d95985eced3a68f53f51#a409f7742fcfb1ecf987d95985eced3a68f53f51"
 dependencies = [
  "field",
  "unroll",
@@ -2571,7 +2571,7 @@ dependencies = [
 [[package]]
 name = "mul_div"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?rev=580ad92dec77a478ada40b4f2b85d6b868f46d2f#580ad92dec77a478ada40b4f2b85d6b868f46d2f"
+source = "git+https://github.com/matter-labs/zksync-airbender?rev=a409f7742fcfb1ecf987d95985eced3a68f53f51#a409f7742fcfb1ecf987d95985eced3a68f53f51"
 dependencies = [
  "common_constants",
  "prover",
@@ -2583,7 +2583,7 @@ dependencies = [
 [[package]]
 name = "mul_div_unsigned"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?rev=580ad92dec77a478ada40b4f2b85d6b868f46d2f#580ad92dec77a478ada40b4f2b85d6b868f46d2f"
+source = "git+https://github.com/matter-labs/zksync-airbender?rev=a409f7742fcfb1ecf987d95985eced3a68f53f51#a409f7742fcfb1ecf987d95985eced3a68f53f51"
 dependencies = [
  "common_constants",
  "prover",
@@ -2595,7 +2595,7 @@ dependencies = [
 [[package]]
 name = "mul_div_unsigned_verifier"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?rev=580ad92dec77a478ada40b4f2b85d6b868f46d2f#580ad92dec77a478ada40b4f2b85d6b868f46d2f"
+source = "git+https://github.com/matter-labs/zksync-airbender?rev=a409f7742fcfb1ecf987d95985eced3a68f53f51#a409f7742fcfb1ecf987d95985eced3a68f53f51"
 dependencies = [
  "field",
  "unroll",
@@ -2605,7 +2605,7 @@ dependencies = [
 [[package]]
 name = "mul_div_verifier"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?rev=580ad92dec77a478ada40b4f2b85d6b868f46d2f#580ad92dec77a478ada40b4f2b85d6b868f46d2f"
+source = "git+https://github.com/matter-labs/zksync-airbender?rev=a409f7742fcfb1ecf987d95985eced3a68f53f51#a409f7742fcfb1ecf987d95985eced3a68f53f51"
 dependencies = [
  "field",
  "unroll",
@@ -2638,7 +2638,7 @@ checksum = "72ef4a56884ca558e5ddb05a1d1e7e1bfd9a68d9ed024c21704cc98872dae1bb"
 [[package]]
 name = "non_determinism_source"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?rev=580ad92dec77a478ada40b4f2b85d6b868f46d2f#580ad92dec77a478ada40b4f2b85d6b868f46d2f"
+source = "git+https://github.com/matter-labs/zksync-airbender?rev=a409f7742fcfb1ecf987d95985eced3a68f53f51#a409f7742fcfb1ecf987d95985eced3a68f53f51"
 
 [[package]]
 name = "nu-ansi-term"
@@ -3241,7 +3241,7 @@ version = "0.8.2"
 [[package]]
 name = "prover"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?rev=580ad92dec77a478ada40b4f2b85d6b868f46d2f#580ad92dec77a478ada40b4f2b85d6b868f46d2f"
+source = "git+https://github.com/matter-labs/zksync-airbender?rev=a409f7742fcfb1ecf987d95985eced3a68f53f51#a409f7742fcfb1ecf987d95985eced3a68f53f51"
 dependencies = [
  "blake2s_u32",
  "common_constants",
@@ -3266,7 +3266,7 @@ dependencies = [
 [[package]]
 name = "prover_examples"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?rev=580ad92dec77a478ada40b4f2b85d6b868f46d2f#580ad92dec77a478ada40b4f2b85d6b868f46d2f"
+source = "git+https://github.com/matter-labs/zksync-airbender?rev=a409f7742fcfb1ecf987d95985eced3a68f53f51#a409f7742fcfb1ecf987d95985eced3a68f53f51"
 dependencies = [
  "bincode 1.3.3",
  "common_constants",
@@ -3428,7 +3428,7 @@ dependencies = [
 [[package]]
 name = "reduced_keccak"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?rev=580ad92dec77a478ada40b4f2b85d6b868f46d2f#580ad92dec77a478ada40b4f2b85d6b868f46d2f"
+source = "git+https://github.com/matter-labs/zksync-airbender?rev=a409f7742fcfb1ecf987d95985eced3a68f53f51#a409f7742fcfb1ecf987d95985eced3a68f53f51"
 
 [[package]]
 name = "ref-cast"
@@ -3586,7 +3586,7 @@ checksum = "68b59d645e392e041ad18f5e529ed13242d8405c66bb192f59703ea2137017d0"
 [[package]]
 name = "riscv_common"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?rev=580ad92dec77a478ada40b4f2b85d6b868f46d2f#580ad92dec77a478ada40b4f2b85d6b868f46d2f"
+source = "git+https://github.com/matter-labs/zksync-airbender?rev=a409f7742fcfb1ecf987d95985eced3a68f53f51#a409f7742fcfb1ecf987d95985eced3a68f53f51"
 dependencies = [
  "common_constants",
  "seq-macro",
@@ -3595,7 +3595,7 @@ dependencies = [
 [[package]]
 name = "riscv_transpiler"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?rev=580ad92dec77a478ada40b4f2b85d6b868f46d2f#580ad92dec77a478ada40b4f2b85d6b868f46d2f"
+source = "git+https://github.com/matter-labs/zksync-airbender?rev=a409f7742fcfb1ecf987d95985eced3a68f53f51#a409f7742fcfb1ecf987d95985eced3a68f53f51"
 dependencies = [
  "blake2s_u32",
  "capstone",
@@ -3952,7 +3952,7 @@ dependencies = [
 [[package]]
 name = "setups"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?rev=580ad92dec77a478ada40b4f2b85d6b868f46d2f#580ad92dec77a478ada40b4f2b85d6b868f46d2f"
+source = "git+https://github.com/matter-labs/zksync-airbender?rev=a409f7742fcfb1ecf987d95985eced3a68f53f51#a409f7742fcfb1ecf987d95985eced3a68f53f51"
 dependencies = [
  "add_sub_lui_auipc_mop",
  "bigint_with_control",
@@ -4046,7 +4046,7 @@ dependencies = [
 [[package]]
 name = "shift_binary_csr"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?rev=580ad92dec77a478ada40b4f2b85d6b868f46d2f#580ad92dec77a478ada40b4f2b85d6b868f46d2f"
+source = "git+https://github.com/matter-labs/zksync-airbender?rev=a409f7742fcfb1ecf987d95985eced3a68f53f51#a409f7742fcfb1ecf987d95985eced3a68f53f51"
 dependencies = [
  "common_constants",
  "prover",
@@ -4058,7 +4058,7 @@ dependencies = [
 [[package]]
 name = "shift_binary_csr_verifier"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?rev=580ad92dec77a478ada40b4f2b85d6b868f46d2f#580ad92dec77a478ada40b4f2b85d6b868f46d2f"
+source = "git+https://github.com/matter-labs/zksync-airbender?rev=a409f7742fcfb1ecf987d95985eced3a68f53f51#a409f7742fcfb1ecf987d95985eced3a68f53f51"
 dependencies = [
  "field",
  "unroll",
@@ -4556,7 +4556,7 @@ checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
 [[package]]
 name = "trace_and_split"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?rev=580ad92dec77a478ada40b4f2b85d6b868f46d2f#580ad92dec77a478ada40b4f2b85d6b868f46d2f"
+source = "git+https://github.com/matter-labs/zksync-airbender?rev=a409f7742fcfb1ecf987d95985eced3a68f53f51#a409f7742fcfb1ecf987d95985eced3a68f53f51"
 dependencies = [
  "common_constants",
  "prover",
@@ -4570,7 +4570,7 @@ dependencies = [
 [[package]]
 name = "trace_holder"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?rev=580ad92dec77a478ada40b4f2b85d6b868f46d2f#580ad92dec77a478ada40b4f2b85d6b868f46d2f"
+source = "git+https://github.com/matter-labs/zksync-airbender?rev=a409f7742fcfb1ecf987d95985eced3a68f53f51#a409f7742fcfb1ecf987d95985eced3a68f53f51"
 dependencies = [
  "field",
  "worker",
@@ -4641,7 +4641,7 @@ dependencies = [
 [[package]]
 name = "transcript"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?rev=580ad92dec77a478ada40b4f2b85d6b868f46d2f#580ad92dec77a478ada40b4f2b85d6b868f46d2f"
+source = "git+https://github.com/matter-labs/zksync-airbender?rev=a409f7742fcfb1ecf987d95985eced3a68f53f51#a409f7742fcfb1ecf987d95985eced3a68f53f51"
 dependencies = [
  "blake2s_u32",
  "unroll",
@@ -4736,7 +4736,7 @@ checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 [[package]]
 name = "unified_reduced_machine"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?rev=580ad92dec77a478ada40b4f2b85d6b868f46d2f#580ad92dec77a478ada40b4f2b85d6b868f46d2f"
+source = "git+https://github.com/matter-labs/zksync-airbender?rev=a409f7742fcfb1ecf987d95985eced3a68f53f51#a409f7742fcfb1ecf987d95985eced3a68f53f51"
 dependencies = [
  "common_constants",
  "prover",
@@ -4748,7 +4748,7 @@ dependencies = [
 [[package]]
 name = "unified_reduced_machine_verifier"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?rev=580ad92dec77a478ada40b4f2b85d6b868f46d2f#580ad92dec77a478ada40b4f2b85d6b868f46d2f"
+source = "git+https://github.com/matter-labs/zksync-airbender?rev=a409f7742fcfb1ecf987d95985eced3a68f53f51#a409f7742fcfb1ecf987d95985eced3a68f53f51"
 dependencies = [
  "field",
  "unroll",
@@ -4816,7 +4816,7 @@ checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 [[package]]
 name = "verifier_common"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?rev=580ad92dec77a478ada40b4f2b85d6b868f46d2f#580ad92dec77a478ada40b4f2b85d6b868f46d2f"
+source = "git+https://github.com/matter-labs/zksync-airbender?rev=a409f7742fcfb1ecf987d95985eced3a68f53f51#a409f7742fcfb1ecf987d95985eced3a68f53f51"
 dependencies = [
  "blake2s_u32",
  "cs",
@@ -4831,7 +4831,7 @@ dependencies = [
 [[package]]
 name = "verifier_generator"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?rev=580ad92dec77a478ada40b4f2b85d6b868f46d2f#580ad92dec77a478ada40b4f2b85d6b868f46d2f"
+source = "git+https://github.com/matter-labs/zksync-airbender?rev=a409f7742fcfb1ecf987d95985eced3a68f53f51#a409f7742fcfb1ecf987d95985eced3a68f53f51"
 dependencies = [
  "proc-macro2 1.0.101",
  "prover",
@@ -5294,7 +5294,7 @@ checksum = "f17a85883d4e6d00e8a97c586de764dabcc06133f7f1d55dce5cdc070ad7fe59"
 [[package]]
 name = "worker"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?rev=580ad92dec77a478ada40b4f2b85d6b868f46d2f#580ad92dec77a478ada40b4f2b85d6b868f46d2f"
+source = "git+https://github.com/matter-labs/zksync-airbender?rev=a409f7742fcfb1ecf987d95985eced3a68f53f51#a409f7742fcfb1ecf987d95985eced3a68f53f51"
 dependencies = [
  "num_cpus",
  "rayon",
@@ -5499,7 +5499,7 @@ dependencies = [
 [[package]]
 name = "zkos-wrapper"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zkos-wrapper.git?rev=024350a3f9ded2e3c43be6153921034c7c80455d#024350a3f9ded2e3c43be6153921034c7c80455d"
+source = "git+https://github.com/matter-labs/zkos-wrapper.git?rev=0f815df44c1379ee768b392bf85a90a43e22472e#0f815df44c1379ee768b392bf85a90a43e22472e"
 dependencies = [
  "anyhow",
  "bincode 2.0.1",
@@ -5623,7 +5623,6 @@ dependencies = [
  "bincode 2.0.1",
  "clap",
  "cli",
- "era_cudart 0.156.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "execution_utils",
  "protocol_version",
  "reqwest",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,23 +28,22 @@ zksync_os_fri_prover = { path = "crates/zksync_os_fri_prover" }
 # zksync-airbender dependencies
 # NOTE: the URL form and ref must match the ones used by zkos-wrapper so that
 # cargo unifies the git source instead of building two copies of the airbender crates.
-# rev 580ad92d = the v0.6.0-rc.1 tag commit (3f8f8e54, matter-labs/zksync-airbender#340:
-# multi-batch proof combining in the unified layer) plus the two additive commits of
-# matter-labs/zksync-airbender#378 (`ProgramProver::program_commitment()`,
-# `GpuConfig::arena_blocks`), which this workspace uses.
+# rev a409f774 = the v0.6.0-rc.1 tag commit (3f8f8e54, matter-labs/zksync-airbender#340:
+# multi-batch proof combining in the unified layer) plus the single additive commit of
+# matter-labs/zksync-airbender#378 (`ProgramProver::program_commitment()`).
 # TODO(airbender-378): move back to a tag once #378 lands in the next airbender +
 # zkos-wrapper tag pair (bump both pins in lockstep).
-zksync_airbender_execution_utils = { package = "execution_utils", git = "https://github.com/matter-labs/zksync-airbender", rev = "580ad92dec77a478ada40b4f2b85d6b868f46d2f" }
-zksync_airbender_cli = { package = "cli", git = "https://github.com/matter-labs/zksync-airbender", rev = "580ad92dec77a478ada40b4f2b85d6b868f46d2f" }
+zksync_airbender_execution_utils = { package = "execution_utils", git = "https://github.com/matter-labs/zksync-airbender", rev = "a409f7742fcfb1ecf987d95985eced3a68f53f51" }
+zksync_airbender_cli = { package = "cli", git = "https://github.com/matter-labs/zksync-airbender", rev = "a409f7742fcfb1ecf987d95985eced3a68f53f51" }
 
 # zkos-wrapper dependencies
-# rev 024350a3 = branch dz-aux-params-unified-chain-airbender-378: the v0.6.0-rc.1 tag
+# rev 0f815df4 = branch dz-aux-params-unified-chain-airbender-378: the v0.6.0-rc.1 tag
 # commit (32e7eb42, matter-labs/zkos-wrapper#75: host-side setup cache carried between
 # SNARK wrapper sessions) plus matter-labs/zkos-wrapper#77 (fold the unified layer into
 # `BinaryCommitment::aux_params`, required for `check_aux_params` to accept real V8
 # proofs) plus a pin bump pointing its airbender deps at the same rev as above.
 # TODO(airbender-378): move back to a tag together with the airbender pin above.
-zkos_wrapper = { package = "zkos-wrapper", git = "https://github.com/matter-labs/zkos-wrapper.git", rev = "024350a3f9ded2e3c43be6153921034c7c80455d" }
+zkos_wrapper = { package = "zkos-wrapper", git = "https://github.com/matter-labs/zkos-wrapper.git", rev = "0f815df44c1379ee768b392bf85a90a43e22472e" }
 
 # zksync-crypto dependencies
 # NOTE: must use the same source spec as zkos-wrapper so cargo unifies the git deps
@@ -53,7 +52,6 @@ zkos_wrapper = { package = "zkos-wrapper", git = "https://github.com/matter-labs
 crypto_codegen = { package = "zksync_solidity_vk_codegen", git = "https://github.com/matter-labs/zksync-crypto.git", branch = "oh_for_wrapper" }
 
 # external dependencies
-era_cudart = "=0.156.0"
 anyhow = "1.0.103"
 memmap2 = "0.9.11"
 async-trait = "0.1"

--- a/crates/zksync_os_fri_prover/Cargo.toml
+++ b/crates/zksync_os_fri_prover/Cargo.toml
@@ -35,9 +35,5 @@ vise.workspace = true
 vise-exporter.workspace = true
 url.workspace = true
 
-[dependencies.era_cudart]
-workspace = true
-optional = true
-
 [features]
-gpu = ["dep:era_cudart", "zksync_airbender_cli/gpu"]
+gpu = ["zksync_airbender_cli/gpu"]

--- a/crates/zksync_os_fri_prover/src/lib.rs
+++ b/crates/zksync_os_fri_prover/src/lib.rs
@@ -10,8 +10,8 @@ use clap::Parser;
 use protocol_version::{ProgramCommitment, SupportedProtocolVersions};
 use tracing_subscriber::{EnvFilter, FmtSubscriber};
 use zksync_airbender_cli::prover_utils::{
-    serialize_to_file, GpuConfig, GpuMemoryPreset, ProgramProver, ProgramProverConfig,
-    ProgramSource, ProofTarget, SecurityLevel,
+    serialize_to_file, ProgramProver, ProgramProverConfig, ProgramSource, ProofTarget,
+    SecurityLevel,
 };
 use zksync_airbender_execution_utils::unrolled::UnrolledProgramProof;
 use zksync_sequencer_proof_client::{
@@ -82,37 +82,6 @@ pub fn init_tracing() {
 /// verifier binaries and therefore the recursion chain the proofs carry.
 pub const PROVING_SECURITY_LEVEL: SecurityLevel = SecurityLevel::Security80;
 
-/// Device arena size for the FRI prover, in 1 MiB allocator blocks.
-///
-/// `None` (the preset's fixed size) whenever the device is untouched and the preset fits, so
-/// the common single-phase case is unchanged. Otherwise the arena is trimmed to the free
-/// memory less a reserve for the CUDA context and per-circuit working buffers.
-#[cfg(feature = "gpu")]
-fn fri_arena_blocks() -> Option<usize> {
-    /// Preset arena (`LOW_ARENA_BYTES`), in blocks.
-    const PRESET_BLOCKS: usize = 23_085_449_216 / (1 << 20);
-    /// Headroom the prover needs on top of the arena. Measured at ~306 MiB on an L4; 384
-    /// leaves margin without trimming when the preset would still have fit.
-    const RESERVE_BLOCKS: usize = 384;
-
-    let (free, _total) = era_cudart::memory::memory_get_info().ok()?;
-    let free_blocks = free / (1 << 20);
-    if free_blocks >= PRESET_BLOCKS + RESERVE_BLOCKS {
-        return None;
-    }
-    let usable = free_blocks.saturating_sub(RESERVE_BLOCKS);
-    tracing::info!(
-        "trimming FRI arena to {usable} blocks ({} MiB free, preset wants {PRESET_BLOCKS})",
-        free_blocks
-    );
-    Some(usable)
-}
-
-#[cfg(not(feature = "gpu"))]
-fn fri_arena_blocks() -> Option<usize> {
-    None
-}
-
 pub fn create_prover(binary_path: &Path) -> anyhow::Result<ProgramProver> {
     let source = ProgramSource::from_paths(
         binary_path
@@ -129,22 +98,12 @@ pub fn create_prover(binary_path: &Path) -> anyhow::Result<ProgramProver> {
     let config = ProgramProverConfig {
         // Recursion up to the unified layer: the compact form expected by the SNARK wrapper.
         target: ProofTarget::RecursionUnified,
-        // 100-bit security. Selects the `*_security_100_bits` recursion verifier binaries, so
-        // it changes the recursion chain (and therefore the program commitment and the VK) -
-        // it is not a knob that can be flipped independently of those constants.
+        // The level selects the recursion verifier binaries, so it changes the recursion chain
+        // (and therefore the program commitment and the VK) - not a knob that can be flipped
+        // independently of those constants.
         security_level: PROVING_SECURITY_LEVEL,
-        // Size the arena to what is actually free rather than taking the preset's fixed
-        // 21.5 GiB. The preset size is nearly the whole device on a 24GB-class card, so once
-        // anything else has touched the GPU - a SNARK phase in the same process, say - the
-        // arena can no longer be re-reserved even though the free total still exceeds it.
-        // Fitting the arena to free memory lets the process alternate FRI and SNARK
-        // indefinitely without tearing the device down (which would discard the wrapper and
-        // combiner caches).
-        gpu: GpuConfig {
-            memory_preset: GpuMemoryPreset::Low,
-            arena_blocks: fri_arena_blocks(),
-            ..Default::default()
-        },
+        // Memory preset is left at `Auto`, which takes the larger arena when the device can
+        // hold it and falls back to the low-VRAM one otherwise.
         ..Default::default()
     };
     ProgramProver::new(source, config).map_err(|e| anyhow::anyhow!("failed to create prover: {e}"))


### PR DESCRIPTION
Reverts the arena sizing from #154. It is not reliable, and we are no longer targeting 24GB-class cards.

Measured on an L4 (`LOW_ARENA_BYTES` = 21.5 GiB):

| arena | outcome |
|---|---|
| 21.500 GiB (preset) | works on a pristine device; cannot be allocated once fragmented |
| 21.309 GiB | works |
| 21.164 GiB | fills to 20.967 GiB, then fails a 256 MiB request mid-proof |
| 20.828 GiB | fills to 20.700 GiB, then fails a 256 MiB request mid-proof |

Beating the fragmentation needs a shrink of >=191 MiB; the workload tolerates <=191 MiB. The constraints meet at a point, so the size that works depends only on how much the SNARK phase left behind - the earlier 3-cycle validation passed by luck of that arithmetic. The allocator also fills ~99% of whatever pool it is given and then fails rather than evicting, so a smaller arena moves the failure from startup into proving, which is worse.

Also switches the hardcoded `Low` preset to `Auto` (takes the larger arena where the device can hold it), and repoints the airbender/zkos-wrapper pins now that `GpuConfig::arena_blocks` is gone from matter-labs/zksync-airbender#378.

On a >=40GB card the fragmentation is not expected to bite at all, since the arena is a much smaller fraction of the device - to be confirmed there.