### PR TITLE
fix: bound sequencer requests by inactivity instead of a total deadline

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ cargo run --release --features gpu --bin zksync_os_fri_prover -- --sequencer-url
 
 Specify optional `--iterations` argument to run FRI prover N times and then exit.
 Specify optional `--path` argument if you want to serialize FRI proof to file.
-Specify `--request_timeout_secs` argument to set a timeout for HTTP requests (default value is 2s).
+Specify `--request-timeout-secs` to override the backstop on a whole HTTP request (default 600s). Requests are bounded by inactivity, not by a fixed deadline, because a pick response carries the whole prover input.
 Specify `--sequencer-urls` to provide a comma-separated list of sequencer URLs to poll in round-robin fashion.
 
 Note: the app program consists of the `.bin` file passed via `--app-bin-path` **and** its
@@ -75,7 +75,7 @@ RUST_MIN_STACK=267108864 cargo run --release --features gpu --bin zksync_os_snar
 ```
 
 Specify optional `--iterations` argument to run SNARK prover N times and then exit.
-Specify `--request_timeout_secs` argument to set a timeout for HTTP requests (default value is 2s).
+Specify `--request-timeout-secs` to override the backstop on a whole HTTP request (default 600s). Requests are bounded by inactivity, not by a fixed deadline, because a pick response carries the whole prover input.
 Specify `--sequencer-urls` to provide a comma-separated list of sequencer URLs to poll in round-robin fashion.
 
 **This one is only needed if you want to manually upload.**

--- a/crates/sequencer_proof_client/src/lib.rs
+++ b/crates/sequencer_proof_client/src/lib.rs
@@ -5,7 +5,7 @@ pub mod sequencer_endpoint;
 pub mod sequencer_proof_client;
 
 pub use sequencer_endpoint::SequencerEndpoint;
-pub use sequencer_proof_client::SequencerProofClient;
+pub use sequencer_proof_client::{RequestTimeouts, SequencerProofClient};
 
 use crate::metrics::SEQUENCER_CLIENT_METRICS;
 use async_trait::async_trait;

--- a/crates/sequencer_proof_client/src/main.rs
+++ b/crates/sequencer_proof_client/src/main.rs
@@ -3,7 +3,8 @@ use clap::{Parser, Subcommand};
 use tracing_subscriber::{fmt, EnvFilter};
 use zkos_wrapper::SnarkWrapperProof;
 use zksync_sequencer_proof_client::{
-    FriJobInputs, L2BatchNumber, ProofClient, SequencerEndpoint, SequencerProofClient,
+    FriJobInputs, L2BatchNumber, ProofClient, RequestTimeouts, SequencerEndpoint,
+    SequencerProofClient,
 };
 
 #[derive(Parser)]
@@ -48,7 +49,7 @@ impl Cli {
                 .clone()
                 .expect("called sequencer_client() before init()"),
             "cli_client".to_string(),
-            None,
+            RequestTimeouts::default(),
             vec![],
         )
     }

--- a/crates/sequencer_proof_client/src/sequencer_proof_client.rs
+++ b/crates/sequencer_proof_client/src/sequencer_proof_client.rs
@@ -16,6 +16,28 @@ use reqwest::StatusCode;
 use url::Url;
 use zkos_wrapper::SnarkWrapperProof;
 
+/// A job download can be hundreds of MB, so requests are bounded by inactivity rather than by a
+/// deadline that would have to scale with the payload.
+#[derive(Debug, Clone, Copy)]
+pub struct RequestTimeouts {
+    pub connect: Duration,
+    /// Reset by every response body frame, so a download that keeps progressing is never cut off.
+    /// Not reset while waiting for the response head.
+    pub read: Duration,
+    /// Backstop for a transfer that progresses but never ends.
+    pub total: Option<Duration>,
+}
+
+impl Default for RequestTimeouts {
+    fn default() -> Self {
+        Self {
+            connect: Duration::from_secs(5),
+            read: Duration::from_secs(10),
+            total: Some(Duration::from_secs(600)),
+        }
+    }
+}
+
 #[derive(Debug)]
 pub struct SequencerProofClient {
     client: reqwest::Client,
@@ -30,7 +52,6 @@ impl SequencerProofClient {
     /// # Arguments
     /// * `endpoint` - The sequencer endpoint (URL + optional credentials)
     /// * `prover_name` - The name of the prover (used for identification in sequencer prover api)
-    /// * `timeout` - Optional timeout for requests (None defaults to 2 seconds)
     /// * `supported_vk_hashes` - VK hashes this prover supports; sent on pick requests so the
     ///   sequencer only assigns jobs of these versions. Empty means no declaration - the
     ///   sequencer will offer jobs of any version.
@@ -40,7 +61,7 @@ impl SequencerProofClient {
     pub fn new(
         endpoint: SequencerEndpoint,
         prover_name: String,
-        timeout: Option<Duration>,
+        timeouts: RequestTimeouts,
         supported_vk_hashes: Vec<String>,
     ) -> anyhow::Result<Self> {
         let mut headers = HeaderMap::new();
@@ -62,11 +83,14 @@ impl SequencerProofClient {
             );
         }
 
-        let client = reqwest::Client::builder()
-            .timeout(timeout.unwrap_or(Duration::from_secs(2)))
-            .default_headers(headers)
-            .build()
-            .context("Failed to build reqwest client")?;
+        let mut builder = reqwest::Client::builder()
+            .connect_timeout(timeouts.connect)
+            .read_timeout(timeouts.read)
+            .default_headers(headers);
+        if let Some(total) = timeouts.total {
+            builder = builder.timeout(total);
+        }
+        let client = builder.build().context("Failed to build reqwest client")?;
 
         Ok(Self {
             client,
@@ -81,7 +105,6 @@ impl SequencerProofClient {
     /// # Arguments
     /// * `endpoints` - A vector of sequencer endpoints
     /// * `prover_name` - The name of the prover (used for identification in sequencer prover api)
-    /// * `timeout` - Optional timeout for requests (None defaults to 2 seconds)
     /// * `supported_vk_hashes` - VK hashes this prover supports; sent on pick requests so the
     ///   sequencer only assigns jobs of these versions. Empty means no declaration - the
     ///   sequencer will offer jobs of any version.
@@ -92,7 +115,7 @@ impl SequencerProofClient {
     pub fn new_clients(
         endpoints: Vec<SequencerEndpoint>,
         prover_name: String,
-        timeout: Option<Duration>,
+        timeouts: RequestTimeouts,
         supported_vk_hashes: Vec<String>,
     ) -> anyhow::Result<Vec<Box<dyn ProofClient + Send + Sync>>> {
         if endpoints.is_empty() {
@@ -107,7 +130,7 @@ impl SequencerProofClient {
                 let client = SequencerProofClient::new(
                     endpoint,
                     prover_name.clone(),
-                    timeout,
+                    timeouts,
                     supported_vk_hashes.clone(),
                 )
                 .with_context(|| {
@@ -398,8 +421,13 @@ mod tests {
     fn test_client_strips_credentials() {
         let endpoint = SequencerEndpoint::parse("http://user:password123@localhost:3124").unwrap();
 
-        let client = SequencerProofClient::new(endpoint, "test_prover".to_string(), None, vec![])
-            .expect("failed to create client");
+        let client = SequencerProofClient::new(
+            endpoint,
+            "test_prover".to_string(),
+            RequestTimeouts::default(),
+            vec![],
+        )
+        .expect("failed to create client");
 
         // URL should be clean (no credentials)
         let url = client.sequencer_url();
@@ -411,8 +439,13 @@ mod tests {
     #[test]
     fn test_pick_query_without_supported_vk_hashes() {
         let endpoint = SequencerEndpoint::parse("http://localhost:3124").unwrap();
-        let client = SequencerProofClient::new(endpoint, "test_prover".to_string(), None, vec![])
-            .expect("failed to create client");
+        let client = SequencerProofClient::new(
+            endpoint,
+            "test_prover".to_string(),
+            RequestTimeouts::default(),
+            vec![],
+        )
+        .expect("failed to create client");
 
         assert_eq!(client.pick_query(), "id=test_prover");
     }
@@ -423,7 +456,7 @@ mod tests {
         let client = SequencerProofClient::new(
             endpoint,
             "test_prover".to_string(),
-            None,
+            RequestTimeouts::default(),
             vec!["0xaaaa".to_string(), "0xbbbb".to_string()],
         )
         .expect("failed to create client");
@@ -434,12 +467,47 @@ mod tests {
         );
     }
 
+    /// The FRI prover counts `fri_prover_timeout_errors` by asking `reqwest::Error::is_timeout()`,
+    /// so a read timeout has to keep answering yes.
+    #[tokio::test]
+    async fn read_timeout_is_reported_as_a_timeout() {
+        let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+        let addr = listener.local_addr().unwrap();
+        std::thread::spawn(move || {
+            let _accepted = listener.accept();
+            std::thread::park();
+        });
+
+        let client = SequencerProofClient::new(
+            SequencerEndpoint::parse(&format!("http://{addr}")).unwrap(),
+            "test_prover".to_string(),
+            RequestTimeouts {
+                read: Duration::from_millis(200),
+                ..Default::default()
+            },
+            vec![],
+        )
+        .expect("failed to create client");
+
+        let err = client.pick_fri_job().await.expect_err("must time out");
+        assert!(
+            err.downcast_ref::<reqwest::Error>()
+                .is_some_and(reqwest::Error::is_timeout),
+            "{err:#}"
+        );
+    }
+
     #[test]
     fn test_client_without_credentials() {
         let endpoint = SequencerEndpoint::parse("http://localhost:3124").unwrap();
 
-        let client = SequencerProofClient::new(endpoint, "test_prover".to_string(), None, vec![])
-            .expect("failed to create client");
+        let client = SequencerProofClient::new(
+            endpoint,
+            "test_prover".to_string(),
+            RequestTimeouts::default(),
+            vec![],
+        )
+        .expect("failed to create client");
 
         let url = client.sequencer_url();
         assert_eq!(url.as_str(), "http://localhost:3124/");

--- a/crates/zksync_os_fri_prover/src/lib.rs
+++ b/crates/zksync_os_fri_prover/src/lib.rs
@@ -14,7 +14,7 @@ use zksync_airbender_cli::prover_utils::{
 };
 use zksync_airbender_execution_utils::unrolled::UnrolledProgramProof;
 use zksync_sequencer_proof_client::{
-    FriJobInputs, ProofClient, SequencerEndpoint, SequencerProofClient,
+    FriJobInputs, ProofClient, RequestTimeouts, SequencerEndpoint, SequencerProofClient,
 };
 
 use crate::metrics::FRI_PROVER_METRICS;
@@ -58,9 +58,10 @@ pub struct Args {
     #[arg(long, default_value = "3124")]
     pub prometheus_port: u16,
 
-    /// Timeout for HTTP requests to sequencer in seconds. If no response is received within this time, the prover will exit.
-    #[arg(long, default_value = "2")]
-    pub request_timeout_secs: u64,
+    /// Overrides the backstop on a whole request, in seconds. A job download is bounded by
+    /// inactivity, so this only needs to change for a sequencer that is reachable but pathological.
+    #[arg(long)]
+    pub request_timeout_secs: Option<u64>,
 
     /// Name of the prover for identification in the sequencer's prover api
     #[arg(long, default_value = "unknown_prover")]
@@ -109,7 +110,10 @@ pub fn create_proof(
 }
 
 pub async fn run(args: Args) -> anyhow::Result<()> {
-    let timeout = Duration::from_secs(args.request_timeout_secs);
+    let mut timeouts = RequestTimeouts::default();
+    if let Some(total) = args.request_timeout_secs {
+        timeouts.total = Some(Duration::from_secs(total));
+    }
 
     tracing::info!(
         "Creating {} sequencer proof clients for urls: {:?}",
@@ -123,7 +127,7 @@ pub async fn run(args: Args) -> anyhow::Result<()> {
     let clients = SequencerProofClient::new_clients(
         args.sequencer_urls,
         args.prover_name,
-        Some(timeout),
+        timeouts,
         supported_versions.vk_hashes(),
     )
     .context("failed to create sequencer proof clients")?;
@@ -139,10 +143,7 @@ pub async fn run(args: Args) -> anyhow::Result<()> {
         .unwrap_or_else(|| Path::new(&manifest_path).join("../../multiblock_batch.bin"));
     let prover = create_prover(&binary_path)?;
 
-    tracing::info!(
-        "Starting Zksync OS FRI prover with request timeout of {}s",
-        args.request_timeout_secs
-    );
+    tracing::info!(?timeouts, "Starting Zksync OS FRI prover");
 
     let mut proof_count = 0;
 
@@ -221,7 +222,6 @@ pub async fn run_inner(
                     "Timeout waiting for response from sequencer {}: {err}",
                     client.sequencer_url()
                 );
-                tracing::error!("Exiting prover due to timeout");
                 FRI_PROVER_METRICS.timeout_errors.inc();
                 return Ok(false);
             }
@@ -328,7 +328,6 @@ pub async fn run_inner(
                     client.sequencer_url(),
                     err
                 );
-                tracing::error!("Exiting prover due to timeout");
                 FRI_PROVER_METRICS.timeout_errors.inc();
             } else {
                 tracing::error!(

--- a/crates/zksync_os_prover_service/src/lib.rs
+++ b/crates/zksync_os_prover_service/src/lib.rs
@@ -12,7 +12,7 @@ use anyhow::Context;
 use clap::Parser;
 use protocol_version::SupportedProtocolVersions;
 use tracing_subscriber::{EnvFilter, FmtSubscriber};
-use zksync_sequencer_proof_client::{SequencerEndpoint, SequencerProofClient};
+use zksync_sequencer_proof_client::{RequestTimeouts, SequencerEndpoint, SequencerProofClient};
 
 pub mod metrics;
 
@@ -113,7 +113,7 @@ pub async fn run(args: Args) -> anyhow::Result<()> {
     let clients = SequencerProofClient::new_clients(
         args.sequencer_urls,
         "prover_service".to_string(),
-        None,
+        RequestTimeouts::default(),
         supported_versions.vk_hashes(),
     )
     .context("failed to create sequencer proof clients")?;

--- a/crates/zksync_os_snark_prover/src/lib.rs
+++ b/crates/zksync_os_snark_prover/src/lib.rs
@@ -338,7 +338,6 @@ pub async fn run_inner(
                     "Timeout waiting for response from sequencer {}: {e:?}",
                     client.sequencer_url()
                 );
-                tracing::error!("Exiting prover due to timeout");
                 SNARK_PROVER_METRICS.timeout_errors.inc();
                 return Ok(false);
             }
@@ -462,7 +461,6 @@ pub async fn run_inner(
                     end_batch,
                     client.sequencer_url()
                 );
-                tracing::error!("Exiting prover due to timeout");
                 SNARK_PROVER_METRICS.timeout_errors.inc();
             } else {
                 tracing::error!(

--- a/crates/zksync_os_snark_prover/src/main.rs
+++ b/crates/zksync_os_snark_prover/src/main.rs
@@ -5,7 +5,7 @@ use protocol_version::SupportedProtocolVersions;
 use serde::{Deserialize, Serialize};
 use tokio::sync::watch;
 use zksync_os_snark_prover::{init_tracing, metrics, run_linking_fri_snark};
-use zksync_sequencer_proof_client::{SequencerEndpoint, SequencerProofClient};
+use zksync_sequencer_proof_client::{RequestTimeouts, SequencerEndpoint, SequencerProofClient};
 
 #[derive(Default, Debug, Serialize, Deserialize, Parser, Clone)]
 pub struct SetupOptions {
@@ -51,9 +51,11 @@ enum Commands {
         /// Port to run the Prometheus metrics server on
         #[arg(long, default_value = "3124")]
         prometheus_port: u16,
-        /// Timeout for HTTP requests to sequencer in seconds. If no response is received within this time, the prover will exit.
-        #[arg(long, default_value = "2")]
-        request_timeout_secs: u64,
+        /// Overrides the backstop on a whole request, in seconds. A job download is bounded by
+        /// inactivity, so this only needs to change for a sequencer that is reachable but
+        /// pathological.
+        #[arg(long)]
+        request_timeout_secs: Option<u64>,
         /// Disable ZK for SNARK proofs
         #[arg(long, default_value_t = false)]
         disable_zk: bool,
@@ -103,7 +105,10 @@ fn main() -> anyhow::Result<()> {
                     metrics::start_metrics_exporter(prometheus_port, stop_receiver).await
                 });
 
-                let timeout = Duration::from_secs(request_timeout_secs);
+                let mut timeouts = RequestTimeouts::default();
+                if let Some(total) = request_timeout_secs {
+                    timeouts.total = Some(Duration::from_secs(total));
+                }
 
                 tracing::info!(
                     "Creating {} sequencer proof clients for urls: {:?}",
@@ -114,15 +119,12 @@ fn main() -> anyhow::Result<()> {
                 let clients = SequencerProofClient::new_clients(
                     sequencer_urls,
                     prover_name,
-                    Some(timeout),
+                    timeouts,
                     supported_versions.vk_hashes(),
                 )
                 .expect("failed to create sequencer proof clients");
 
-                tracing::info!(
-                    "Starting zksync_os_snark_prover with request timeout of {}s",
-                    request_timeout_secs
-                );
+                tracing::info!(?timeouts, "Starting zksync_os_snark_prover");
 
                 // The proving chain is synchronous and stack-hungry; drive it from a
                 // runtime blocking thread (which gets the explicit stack size above)


### PR DESCRIPTION
A pick response carries the entire prover input, 247MB for the fat batch in INC-37. The client used
one total request deadline (`--request-timeout-secs`, default 2s), which has two problems: its
correct value scales with batch size, which is unbounded, and it was also the only detector of a
wedged sequencer, so raising it to cover fat batches delays that detection.

Now `read_timeout` (10s) does the work. reqwest resets it on every response body frame, so a
download that keeps progressing is never cut off, while a connection that stops delivering is caught
in 10s - 2x faster than the 20s deadline these fleets carry today. `connect_timeout` (5s) covers
opening a new connection; in steady state provers reuse pooled connections, so `read_timeout` is the
detector that matters. A 600s total remains as a backstop, because `read_timeout` alone cannot bound
a transfer that trickles forever, and nothing else unsticks a prover mid-download.

Evidence for the numbers: after the flag was raised to 20s during INC-37 the fat batches downloaded
and proved, so the transfer sustained >12MB/s; a 10s window with no frame at all is far outside
anything healthy. 600s allows 247MB at 0.4MB/s.

Note `read_timeout` is not reset while waiting for the response head, so it also acts as a fixed
deadline on connect plus request-body upload plus first byte. That bounds proof submissions at 10s,
which fits: a FRI proof is a few hundred KB.

Rollout: `--request-timeout-secs` stays parseable so nothing crash-loops on an unknown flag, but it
now overrides the backstop - any fleet still passing `=20` keeps a fixed 20s deadline, and the arg
has to be dropped in gitops (six FRI fleets) for this to take effect there. Everywhere else, the 2s
default is gone as soon as the image ships. `prover-service` passed no timeout at all and silently
got the 2s default; it now gets the same values.

PLA-1228.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
